### PR TITLE
Add phcovid_plot module

### DIFF
--- a/phcovid/__init__.py
+++ b/phcovid/__init__.py
@@ -1,2 +1,2 @@
-from phcovid import *
-from phcovid_plot import *
+from .phcovid import *
+from .phcovid_plot import *

--- a/phcovid/__init__.py
+++ b/phcovid/__init__.py
@@ -1,1 +1,2 @@
 from phcovid import *
+from phcovid_plot import *

--- a/phcovid/phcovid_plot.py
+++ b/phcovid/phcovid_plot.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+def get_case_plot(df, date_col = 'confirmation_date'):
+    """
+    This function a.) plots the growth of cases in the given df
+    and prints the date of first and latest confirmed case.
+    
+    df:
+        full extract or slice of original dataframe from get_cases()
+    date_col:
+        column name of date attribute
+        current decision is to use column 'confirmation date.'
+        since column 'date' has more missing values. 
+    """
+
+    def get_date_part(d):
+        #Function removes empty/invalid dates
+        #Once data cleaning in get_cases() is finalized, we can depracate this fucntion and section
+        try:
+            date = pd.to_datetime(d)
+            return d
+        except ValueError:
+            return np.nan
+
+    case_dates = df[date_col]
+    case_dates = case_dates.apply(lambda x: get_date_part(x))
+    case_count = pd.DataFrame(case_dates[~case_dates.isnull()].unique())
+    case_count.rename(columns = {0: 'date'}, inplace = True)
+    
+    for row in case_count.itertuples():
+        current_date = getattr(row, 'date')
+        index = getattr(row, 'Index')
+        
+        #column 'case_count' stores number of cases in that specific date. 
+        case_count.loc[index, 'case_count'] = len(df[df[date_col]==current_date])
+
+        #create cumulative sum of case_count
+        if(index == 0):
+            case_count.loc[index, 'case_count'] = 0
+        else:
+            case_count.loc[index, 'case_count'] += case_count.loc[index-1, 'case_count']
+
+        
+    
+    #print first and latest confirmed date
+    print("First Confirmed Case: ", str(min(pd.to_datetime(case_count['date']))).split(' ')[0])
+    print("Latest Confirmed Case: ", str(max(pd.to_datetime(case_count['date']))).split(' ')[0])
+    
+    #plot
+    plt.plot(case_count['date'], case_count['case_count'])

--- a/sample/.gitignore
+++ b/sample/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints/

--- a/sample/Cases Network Analysis.ipynb
+++ b/sample/Cases Network Analysis.ipynb
@@ -1,0 +1,959 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part I: Read Data and Pre-Process"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import phcovid package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import os, sys\n",
+    "package_dir = os.path.normpath(os.getcwd() + os.sep + os.pardir) + os.sep +'phcovid'\n",
+    "sys.path.append(package_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from phcovid import get_cases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use get_cases module to extract latest data regarding PH Covid-19 cases in an analysis friendly format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = get_cases()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>case_no</th>\n",
+       "      <th>age</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>nationality</th>\n",
+       "      <th>residence</th>\n",
+       "      <th>travel_history</th>\n",
+       "      <th>symptoms</th>\n",
+       "      <th>confirmation_date</th>\n",
+       "      <th>facility</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "      <th>status</th>\n",
+       "      <th>epi_link</th>\n",
+       "      <th>date</th>\n",
+       "      <th>contacts</th>\n",
+       "      <th>num_contacts</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>PH1</td>\n",
+       "      <td>38.0</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Chinese</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Yes (China); Wife of PH2</td>\n",
+       "      <td></td>\n",
+       "      <td>1/30/2020</td>\n",
+       "      <td>San Lazaro Hospital</td>\n",
+       "      <td>14.613754</td>\n",
+       "      <td>120.980815</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>1/29/2020 16:00</td>\n",
+       "      <td>[PH2]</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>PH2</td>\n",
+       "      <td>44.0</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Chinese</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Yes (China); Husband of PH1</td>\n",
+       "      <td></td>\n",
+       "      <td>1/30/2020</td>\n",
+       "      <td>San Lazaro Hospital</td>\n",
+       "      <td>14.613754</td>\n",
+       "      <td>120.980815</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>1/29/2020 16:00</td>\n",
+       "      <td>[PH1]</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>PH3</td>\n",
+       "      <td>60.0</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Chinese</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Yes (China)</td>\n",
+       "      <td></td>\n",
+       "      <td>1/30/2020</td>\n",
+       "      <td>ACE Medical Center</td>\n",
+       "      <td>9.634451</td>\n",
+       "      <td>123.869198</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>1/29/2020 16:00</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>PH4</td>\n",
+       "      <td>48.0</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Filipino</td>\n",
+       "      <td>Taguig City</td>\n",
+       "      <td>Yes (Japan)</td>\n",
+       "      <td></td>\n",
+       "      <td>3/5/2020</td>\n",
+       "      <td>University of the East Ramon Magsaysay Memoria...</td>\n",
+       "      <td>14.607030</td>\n",
+       "      <td>121.020581</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>3/4/2020 16:00</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>PH5</td>\n",
+       "      <td>62.0</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Filipino</td>\n",
+       "      <td>Rizal</td>\n",
+       "      <td>Husband of PH6</td>\n",
+       "      <td></td>\n",
+       "      <td>3/5/2020</td>\n",
+       "      <td>Research Institute for Tropical Medicine</td>\n",
+       "      <td>14.409523</td>\n",
+       "      <td>121.037122</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>3/4/2020 16:00</td>\n",
+       "      <td>[PH6]</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  case_no   age     sex nationality    residence               travel_history  \\\n",
+       "0     PH1  38.0  Female     Chinese         None     Yes (China); Wife of PH2   \n",
+       "1     PH2  44.0    Male     Chinese         None  Yes (China); Husband of PH1   \n",
+       "2     PH3  60.0  Female     Chinese         None                  Yes (China)   \n",
+       "3     PH4  48.0    Male    Filipino  Taguig City                  Yes (Japan)   \n",
+       "4     PH5  62.0    Male    Filipino        Rizal               Husband of PH6   \n",
+       "\n",
+       "  symptoms confirmation_date  \\\n",
+       "0                  1/30/2020   \n",
+       "1                  1/30/2020   \n",
+       "2                  1/30/2020   \n",
+       "3                   3/5/2020   \n",
+       "4                   3/5/2020   \n",
+       "\n",
+       "                                            facility   latitude   longitude  \\\n",
+       "0                                San Lazaro Hospital  14.613754  120.980815   \n",
+       "1                                San Lazaro Hospital  14.613754  120.980815   \n",
+       "2                                 ACE Medical Center   9.634451  123.869198   \n",
+       "3  University of the East Ramon Magsaysay Memoria...  14.607030  121.020581   \n",
+       "4           Research Institute for Tropical Medicine  14.409523  121.037122   \n",
+       "\n",
+       "  status epi_link             date contacts  num_contacts  \n",
+       "0                  1/29/2020 16:00    [PH2]             1  \n",
+       "1                  1/29/2020 16:00    [PH1]             1  \n",
+       "2                  1/29/2020 16:00       []             0  \n",
+       "3                   3/4/2020 16:00       []             0  \n",
+       "4                   3/4/2020 16:00    [PH6]             1  "
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#For use in graph analysis, we will create a column with case code [PHX] converted to numeric [X]\n",
+    "def parse_ints(s):\n",
+    "    num_list = []\n",
+    "    for i in s:\n",
+    "        num_list = num_list + [i.split('H')[-1]]\n",
+    "    return num_list\n",
+    "        \n",
+    "\n",
+    "df['case_no_int'] = df['case_no'].apply(lambda x: x.split('H')[-1]).astype(int)\n",
+    "df['contacts_int'] = df['contacts'].apply(lambda x: parse_ints(x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part II: Connected Components Analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>Step 1:</b> Create a graph to map all <u>direct connections</u> of each case."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Create an undirected graph of all connections\n",
+    "contact_map = {}\n",
+    "def add_edge(s, d, curr_dict):\n",
+    "    try:\n",
+    "        curr_dict[s].append(d)\n",
+    "    except KeyError:\n",
+    "        curr_dict[s] = []\n",
+    "        curr_dict[s].append(d)\n",
+    "\n",
+    "for row in df.itertuples():\n",
+    "    current = getattr(row, 'case_no_int')\n",
+    "    contact_list = getattr(row, 'contacts_int')\n",
+    "    for c in pd.Series(contact_list).unique():\n",
+    "        add_edge(int(current), int(c), contact_map)\n",
+    "        add_edge(int(c), int(current), contact_map)\n",
+    "    \n",
+    "    if(len(contact_list)==0):\n",
+    "        contact_map[int(current)] = []\n",
+    "\n",
+    "for key in contact_map.keys():\n",
+    "    contact_map[key] = list(set(contact_map[key]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>Step 2:</b> Use Depth First Search on the graph built in Step 1 to a.) identify <i>networks</i> of inter-connected cases and b.) count the number of networks and the number of cases in each network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cnt = len(df)\n",
+    "visited = [False for i in range(1,cnt+2)]\n",
+    "visited_pre = [False for i in range(1,cnt+2)]\n",
+    "parent = [-1 for i in range(1,cnt+2)]\n",
+    "def dfs (v, g):\n",
+    "    #dfs from node v in graph (dict) g\n",
+    "    visited[v] = True\n",
+    "    for node in g[v]:\n",
+    "        if(not visited[node]):\n",
+    "            parent[node] = v\n",
+    "            dfs(node, g)\n",
+    "            \n",
+    "cnt_cc = 0\n",
+    "comp_list = {}\n",
+    "for i in range(1, cnt+1):\n",
+    "    if(not visited[i]):\n",
+    "        cnt_cc+=1\n",
+    "        dfs(i, contact_map)\n",
+    "        comp_list[cnt_cc-1] = []\n",
+    "        \n",
+    "        for j in range(1, cnt+1):\n",
+    "            if(not visited_pre[j] and visited[j]):\n",
+    "                visited_pre[j] = visited[j]\n",
+    "                comp_list[cnt_cc-1].append(j)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>a. Multiple cases, especially the initial ones can be traced to networks of 3+ people where transmission occured.</b> The largest network is comprised of 8 people: [12, 34, 35, 42, 43, 84, 86, 204].\n",
+    "<br>\n",
+    "<br>\n",
+    "<i>List of all networks with 3+ Cases shown below:</i>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "List of all Networks with 3+ cases:\n",
+      "Network 3: ['PH5', 'PH6', 'PH38']\n",
+      "Network 6: ['PH9', 'PH27', 'PH28', 'PH29', 'PH30', 'PH31']\n",
+      "Network 9: ['PH12', 'PH34', 'PH35', 'PH42', 'PH43', 'PH84', 'PH86', 'PH204']\n",
+      "Network 16: ['PH21', 'PH65', 'PH66', 'PH67']\n",
+      "Network 28: ['PH41', 'PH44', 'PH87', 'PH112']\n",
+      "Network 33: ['PH49', 'PH52', 'PH183']\n",
+      "Network 35: ['PH51', 'PH134', 'PH135']\n",
+      "Network 140: ['PH169', 'PH170', 'PH176']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"List of all Networks with 3+ cases:\")\n",
+    "for key in comp_list.keys():\n",
+    "    current_list = []\n",
+    "    if(len(comp_list[key])>=3):\n",
+    "        for i in comp_list[key]:\n",
+    "            current_list = current_list + ['PH' + str(i)]\n",
+    "        print(f'Network {key}: {current_list}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>b. Largest Network (Network 9) has loose connections and is split among multiple hospitals in NCR across 10 days. </b> <br>\n",
+    "<i>Network details are shown below:</i>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>case_no</th>\n",
+       "      <th>age</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>nationality</th>\n",
+       "      <th>residence</th>\n",
+       "      <th>travel_history</th>\n",
+       "      <th>symptoms</th>\n",
+       "      <th>confirmation_date</th>\n",
+       "      <th>facility</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "      <th>status</th>\n",
+       "      <th>epi_link</th>\n",
+       "      <th>date</th>\n",
+       "      <th>contacts</th>\n",
+       "      <th>num_contacts</th>\n",
+       "      <th>case_no_int</th>\n",
+       "      <th>contacts_int</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>PH12</td>\n",
+       "      <td>56.0</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Filipino</td>\n",
+       "      <td>Manila</td>\n",
+       "      <td>Contact of PH42, PH43</td>\n",
+       "      <td></td>\n",
+       "      <td>3/9/2020</td>\n",
+       "      <td>Makati Medical Center</td>\n",
+       "      <td>14.559177</td>\n",
+       "      <td>121.014546</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>3/8/2020 16:00</td>\n",
+       "      <td>[PH42, PH43]</td>\n",
+       "      <td>2</td>\n",
+       "      <td>12</td>\n",
+       "      <td>[42, 43]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33</th>\n",
+       "      <td>PH34</td>\n",
+       "      <td>72.0</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Filipino</td>\n",
+       "      <td>Makati City</td>\n",
+       "      <td>Husband of PH35</td>\n",
+       "      <td></td>\n",
+       "      <td>3/11/2020</td>\n",
+       "      <td>Lung Center of the Philippines</td>\n",
+       "      <td>14.647821</td>\n",
+       "      <td>121.045763</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>3/10/2020 16:00</td>\n",
+       "      <td>[PH35]</td>\n",
+       "      <td>1</td>\n",
+       "      <td>34</td>\n",
+       "      <td>[35]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>34</th>\n",
+       "      <td>PH35</td>\n",
+       "      <td>67.0</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Filipino</td>\n",
+       "      <td>Makati City</td>\n",
+       "      <td>Wife of PH34</td>\n",
+       "      <td></td>\n",
+       "      <td>3/11/2020</td>\n",
+       "      <td>Manila Doctors Hospital</td>\n",
+       "      <td>14.582028</td>\n",
+       "      <td>120.982657</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>3/10/2020 16:00</td>\n",
+       "      <td>[PH34]</td>\n",
+       "      <td>1</td>\n",
+       "      <td>35</td>\n",
+       "      <td>[34]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>41</th>\n",
+       "      <td>PH42</td>\n",
+       "      <td>51.0</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Filipino</td>\n",
+       "      <td>Pasig City</td>\n",
+       "      <td>Japan</td>\n",
+       "      <td></td>\n",
+       "      <td>3/11/2020</td>\n",
+       "      <td>Lung Center of the Philippines</td>\n",
+       "      <td>14.647821</td>\n",
+       "      <td>121.045763</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>3/10/2020 16:00</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>0</td>\n",
+       "      <td>42</td>\n",
+       "      <td>[]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>42</th>\n",
+       "      <td>PH43</td>\n",
+       "      <td>47.0</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Filipino</td>\n",
+       "      <td>Makati City</td>\n",
+       "      <td>Wife is Sister of PH12; Close Contact of PH35</td>\n",
+       "      <td></td>\n",
+       "      <td>3/11/2020</td>\n",
+       "      <td>Lung Center of the Philippines</td>\n",
+       "      <td>14.647821</td>\n",
+       "      <td>121.045763</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>3/10/2020 16:00</td>\n",
+       "      <td>[PH12, PH35]</td>\n",
+       "      <td>2</td>\n",
+       "      <td>43</td>\n",
+       "      <td>[12, 35]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>83</th>\n",
+       "      <td>PH84</td>\n",
+       "      <td>38.0</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Filipino</td>\n",
+       "      <td>Taguig City</td>\n",
+       "      <td>Contact of PH43</td>\n",
+       "      <td></td>\n",
+       "      <td>3/13/2020</td>\n",
+       "      <td>Research Institute for Tropical Medicine</td>\n",
+       "      <td>14.409523</td>\n",
+       "      <td>121.037122</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>3/12/2020 16:00</td>\n",
+       "      <td>[PH43]</td>\n",
+       "      <td>1</td>\n",
+       "      <td>84</td>\n",
+       "      <td>[43]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>85</th>\n",
+       "      <td>PH86</td>\n",
+       "      <td>48.0</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>Filipino</td>\n",
+       "      <td>Quezon City</td>\n",
+       "      <td>Contact of PH43</td>\n",
+       "      <td></td>\n",
+       "      <td>3/13/2020</td>\n",
+       "      <td>Research Institute for Tropical Medicine</td>\n",
+       "      <td>14.409523</td>\n",
+       "      <td>121.037122</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>3/12/2020 16:00</td>\n",
+       "      <td>[PH43]</td>\n",
+       "      <td>1</td>\n",
+       "      <td>86</td>\n",
+       "      <td>[43]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>203</th>\n",
+       "      <td>PH204</td>\n",
+       "      <td>32.0</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>Filipino</td>\n",
+       "      <td>for_validation</td>\n",
+       "      <td>Contact of PH35</td>\n",
+       "      <td></td>\n",
+       "      <td>3/18/2020</td>\n",
+       "      <td>Manila Doctors Hospital</td>\n",
+       "      <td>14.582028</td>\n",
+       "      <td>120.982657</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>3/18/2020</td>\n",
+       "      <td>[PH35]</td>\n",
+       "      <td>1</td>\n",
+       "      <td>204</td>\n",
+       "      <td>[35]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    case_no   age     sex nationality       residence  \\\n",
+       "11     PH12  56.0    Male    Filipino          Manila   \n",
+       "33     PH34  72.0    Male    Filipino     Makati City   \n",
+       "34     PH35  67.0  Female    Filipino     Makati City   \n",
+       "41     PH42  51.0  Female    Filipino      Pasig City   \n",
+       "42     PH43  47.0    Male    Filipino     Makati City   \n",
+       "83     PH84  38.0  Female    Filipino     Taguig City   \n",
+       "85     PH86  48.0    Male    Filipino     Quezon City   \n",
+       "203   PH204  32.0  Female    Filipino  for_validation   \n",
+       "\n",
+       "                                    travel_history symptoms confirmation_date  \\\n",
+       "11                           Contact of PH42, PH43                   3/9/2020   \n",
+       "33                                 Husband of PH35                  3/11/2020   \n",
+       "34                                    Wife of PH34                  3/11/2020   \n",
+       "41                                           Japan                  3/11/2020   \n",
+       "42   Wife is Sister of PH12; Close Contact of PH35                  3/11/2020   \n",
+       "83                                 Contact of PH43                  3/13/2020   \n",
+       "85                                 Contact of PH43                  3/13/2020   \n",
+       "203                                Contact of PH35                  3/18/2020   \n",
+       "\n",
+       "                                     facility   latitude   longitude status  \\\n",
+       "11                      Makati Medical Center  14.559177  121.014546          \n",
+       "33             Lung Center of the Philippines  14.647821  121.045763          \n",
+       "34                    Manila Doctors Hospital  14.582028  120.982657          \n",
+       "41             Lung Center of the Philippines  14.647821  121.045763          \n",
+       "42             Lung Center of the Philippines  14.647821  121.045763          \n",
+       "83   Research Institute for Tropical Medicine  14.409523  121.037122          \n",
+       "85   Research Institute for Tropical Medicine  14.409523  121.037122          \n",
+       "203                   Manila Doctors Hospital  14.582028  120.982657          \n",
+       "\n",
+       "    epi_link             date      contacts  num_contacts  case_no_int  \\\n",
+       "11             3/8/2020 16:00  [PH42, PH43]             2           12   \n",
+       "33            3/10/2020 16:00        [PH35]             1           34   \n",
+       "34            3/10/2020 16:00        [PH34]             1           35   \n",
+       "41            3/10/2020 16:00            []             0           42   \n",
+       "42            3/10/2020 16:00  [PH12, PH35]             2           43   \n",
+       "83            3/12/2020 16:00        [PH43]             1           84   \n",
+       "85            3/12/2020 16:00        [PH43]             1           86   \n",
+       "203                 3/18/2020        [PH35]             1          204   \n",
+       "\n",
+       "    contacts_int  \n",
+       "11      [42, 43]  \n",
+       "33          [35]  \n",
+       "34          [34]  \n",
+       "41            []  \n",
+       "42      [12, 35]  \n",
+       "83          [43]  \n",
+       "85          [43]  \n",
+       "203         [35]  "
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[df['case_no_int'].isin(comp_list[9])]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>c. Certain people are also more inclined to spread to a large number of people, despite not being the first case in their network.</b><br>\n",
+    "<i>Shown below are cases with 3 or more contact cases:</i>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "List of all cases with 3+ contacts:\n",
+      "Case: PH9\n",
+      "Contacts: ['PH27', 'PH28', 'PH29', 'PH30', 'PH31']\n",
+      "Case: PH43\n",
+      "Contacts: ['PH35', 'PH12', 'PH86', 'PH84']\n",
+      "Case: PH21\n",
+      "Contacts: ['PH65', 'PH66', 'PH67']\n",
+      "Case: PH35\n",
+      "Contacts: ['PH34', 'PH43', 'PH204']\n",
+      "Case: PH41\n",
+      "Contacts: ['PH112', 'PH44', 'PH87']\n",
+      "Case: PH44\n",
+      "Contacts: ['PH112', 'PH41', 'PH87']\n",
+      "Case: PH87\n",
+      "Contacts: ['PH112', 'PH41', 'PH44']\n",
+      "Case: PH112\n",
+      "Contacts: ['PH41', 'PH44', 'PH87']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"List of all cases with 3+ contacts:\")\n",
+    "for key in contact_map.keys():\n",
+    "    current_list = []\n",
+    "    if(len(contact_map[key])>=3):\n",
+    "        for i in contact_map[key]:\n",
+    "            current_list = current_list + ['PH' + str(i)]\n",
+    "        print(f'Case: PH{key}')\n",
+    "        print(f'Contacts: {current_list}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>d. Currently, there are 274 unique networks, although the number may decrease as more case information is collected. Additionally, 7.14% of all cases come from networks of 2+ people, but this will increase as contact information is updated.</b>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of unique networks:  429\n",
+      "Percentage of Transmissions in networks of 2+: 7.14%\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Number of unique networks: \", cnt_cc)\n",
+    "print(f\"Percentage of Transmissions in networks of 2+: {round(100*(1-cnt_cc/cnt),2)}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part III: Monitoring"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Much has already been said on the importance of <b>flattening the curve.</b> It can be shown that flattening the curve for the country begins with flattening the curve for each of the networks. That is, we should stop the networks of connected cases from growing. This can be accomplished with appropriate personal hygeine measures and social distancing whenever possible. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>Use get_case_plot to show the growth of confirmed cases in PH</b>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from phcovid_plot import get_case_plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<br><i>As of today, the growth of total PH cases is still rising</i>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First Confirmed Case:  2020-01-30\n",
+      "Latest Confirmed Case:  2020-03-23\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAD8CAYAAACRkhiPAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xl8VNX9//HXyQ5JSAg7BBI2ZVFAVnFHXBAX7Ndarda9dalW7WK1rd2/399P229rF5dKq9Zav0Lr8hX3DVBaF/ZN1iQECAl7yAZZJnO+f5wzMsYASUiYTOb9fDzyyMyde8/93HPPPZ+7zVxjrUVERGJTXKQDEBGRyFESEBGJYUoCIiIxTElARCSGKQmIiMQwJQERkRimJCAiEsOUBEREYpiSgIhIDEuIdAAA3bt3t7m5uZEOQ0QkqixZsmS3tbbH0ZTRLpJAbm4uixcvjnQYIiJRxRiz+WjL0OkgEZEYpiQgIhLDlARERGKYkoCISAxTEhARiWFKAiIiMUxJQEQkhrWL7wmIiHQ0NYF6qmrqqawOUFkT+quj0g+rqglQURNg6rCejO6fGbE4lQRERJrJWssT/9rEiqIyKqvrfAdfT2VN3Wcdf219sEll9UxPVhIQEYkm/8rbzX++tpZ+mZ3ISk0iNTmefpmdSEtOIy0lgbTkRNKS40lLTiA1OYF0Pyw1OZ70FDcsLTmB1KQE4uJMRJdFSUBEpJn++F4evbukMPd7Z5KcEB/pcI6KLgyLiDTDxwV7WFi4l1vPHBT1CQCUBEREmuUP722ke1oyV04cEOlQWoWSgIhIEy0u3MuH+Xu49cxBpCRG/1EAKAmIiDTZH+bmkZWaxFWTOsZRACgJiIg0yfKt+/hgwy6+cfogOid1nHtqlARERJrg4bkbyeycyDWTcyIdSqtSEhAROYLV28p4d+1Objp1IGnJHecoAJQERESO6OG5eaSnJHDdqbmRDqXVKQmIiBzGuu3lvPnpdm44JZcuKYmRDqfVKQmIiBzGw3PzSE2K58bTBkY6lDahJCAicgh5Oyt4bVUJ156SS2bnpEiH0yaUBEREDuGRefmkJMTz9Q56FADNSALGmHhjzDJjzKv+/UBjzCfGmI3GmNnGmCQ/PNm/z/Of57ZN6CIibadwdxUvL9/G104eQLe05EiH02aacyRwF7A27P2DwEPW2qFAKXCTH34TUGqtHQI85McTEYkqj8zLIzE+jm+cMSjSobSpJiUBY0w2cCHwF//eAGcDz/tRngYu9a9n+Pf4z6f68UVEosLWvft5adk2vjpxAD3TUyIdTptq6pHA74DvA6FH5XQD9llrA/59EdDPv+4HbAXwn5f58UVEosKj8/OJM4Zbzxwc6VDa3BGTgDHmImCntXZJ+OBGRrVN+Cy83JuNMYuNMYt37drVpGBFRNpa8b4DPL9kK1+ZkE3vjI59FABNOxI4FbjEGFMIzMKdBvodkGmMCX1/Ohso9q+LgP4A/vMMYG/DQq21M621462143v06HFUCyEi0lr+9H4+1hITRwHQhCRgrf2BtTbbWpsLXAnMtdZeDcwDvuxHuw542b+e49/jP59rrf3CkYCISHuzs7yaWYu28uVx2WR37RzpcI6Jo/mewL3Ad4wxebhz/k/44U8A3fzw7wD3HV2IIiLHxuMfFFAftHzzrCGRDuWYadbP4Vlr5wPz/esCYGIj41QDl7dCbCIix8zuyhqe/WQzM8b0ZUC32DgKAH1jWEQEgD8vKKA2EOT2KbFzFABKAiIi7K2q5ZmPNnPRqL4M7pEW6XCOKSUBEYl5T/5rEwfq6rnj7Ng6CgAlARGJcWX763j6w0IuOKE3x/VKj3Q4x5ySgIjEtKc+3ERFTYA7pgyNdCgRoSQgIjGrorqOJ/+1iXNH9GJE3y6RDicilAREJGb97aPNlFcHuPPs2DwKACUBEYlRVTUB/rKggCnH9+DE7IxIhxMxSgIiEpP+/vFmSvfX8a2psXsUAEoCIhKDDtTW8+cFBZw+tDtjB3SNdDgRpSQgIjHnuYVb2F1Zy7di+FpAiJKAiMSU6rp6Hv8gn0kDs5g4MCvS4USckoCIxJTnlxSxo7yGO2P8WkCIkoCIxIy6+iCPzc/npAGZnDJYT70FJQERiSH/u2wb2/Yd4FtnD8GYxp6EG3uUBEQkJtQHLY/Oz2dEny5MOb5npMNpN5QERCQmvL6qhE27q7hDRwGfoyQgIh1eMGh5eG4eQ3qmMW1k70iH064oCYhIh/fu2h2s31HB7VMGExeno4BwSgIi0qFZa3l4Xh4Dsjpz8ai+kQ6n3VESEJEO7YONu1lZVMY3zxpMQry6vIZUIyLSoT0yN48+GSn8x9jsSIfSLikJiEiH9UnBHhYW7uWWMwaRlKDurjGqFRHpsB6el0f3tCSunDgg0qG0W0oCItIhLdtSyoKNu/nG6YNISYyPdDjtlpKAiHRIj8zLI7NzIlefnBPpUNo1JQER6XDWFJfz7tqd3HDKQNKSEyIdTrumJCAiHc4j8/NIS07g+lNyIx1Ku6ckICIdSt7OSl5fVcK1k3PI6JwY6XDaPSUBEelQHp2fR3JCHDedNjDSoUQFJQER6TC27NnPy8uLuXpSDt3SkiMdTlRQEhCRDuNPH+QTbww3nzEo0qFEDSUBEekQSsoO8PziIi4fn02vLimRDidqKAmISIcw84MC6q3l1jMHRzqUqKIkICJRb1dFDc8t3MKXTupH/6zOkQ4nqigJiEjUe+Jfm6gJBPnmWToKaK4jJgFjTIoxZqExZoUx5lNjzM/98IHGmE+MMRuNMbONMUl+eLJ/n+c/z23bRRCRWLZvfy3PfFTIhSf2YVCPtEiHE3WaciRQA5xtrR0NjAGmGWNOBh4EHrLWDgVKgZv8+DcBpdbaIcBDfjwRkTbx1w8Lqaqt5/YpQyIdSlQ6YhKwTqV/m+j/LHA28Lwf/jRwqX89w7/Hfz7VGKOHeopIq6uoruOpfxdy7oheDO/TJdLhRKUmXRMwxsQbY5YDO4F3gHxgn7U24EcpAvr51/2ArQD+8zKgWyNl3myMWWyMWbxr166jWwoRiUl//3gLZQfquENHAS3WpCRgra231o4BsoGJwPDGRvP/G9vrt18YYO1Ma+14a+34Hj16NDVeEREADtTW85cFBZw+tDuj+2dGOpyo1ay7g6y1+4D5wMlApjEm9But2UCxf10E9Afwn2cAe1sjWBGRkFmLtrCnqpZvnT000qFEtabcHdTDGJPpX3cCzgHWAvOAL/vRrgNe9q/n+Pf4z+daa79wJCAi0lI1gXoef7+AiQOzmDgwK9LhRLWmPG2hD/C0MSYelzT+Ya191RizBphljPlPYBnwhB//CeAZY0we7gjgyjaIW0Ri2AtLtrG9vJpfXz4q0qFEvSMmAWvtSuCkRoYX4K4PNBxeDVzeKtGJiDRQVx/k0fl5jO6fyWlDukc6nKin566JSLtlrSUQtNQGgtQGgtTVB3nr0+0UlR7gpxePRHefHz0lARE5Zl5bWcKLS4uorQ9S4zv2UOdeW3/wfW3Av68P0tgVxWG905k6rOexX4AOSElARI6JHeXVfPefy+naOYneGSkkxceRnpJAUnwcSQn+z79OjI8juZFhofEmD+pGXJyOAlqDkoCIHBN/eG8j9UHL7JsnM6CbfumzvdCviIpIm9u0u4pZi7Zy1cQBSgDtjJKAiLS5376zgeSEOO7QF7vaHSUBEWlTq7eV8cqKYm46bSA90vXw9/ZGSUBE2tSv31pPZudEvqGHv7dLSgIi0mY+yt/D+xt2cftZQ+iSkhjpcKQRSgIi0iastfzqrXX0yUjhmsk5kQ5HDkFJQETaxDtrdrBsyz7uPmcoKYnxkQ5HDkFJQERaXX3Q8uu31jOoRyqXjc2OdDhyGEoCItLqXlq2jY07K7nnvONJiFc3055p7YhIq6oJ1PPQOxsYlZ3BtBN6RzocOQIlARFpVc9+vIVt+w5w77Rh+pXPKKAkICKtprImwMPz8jhtSHdO1W/9RwUlARFpNX9ZUMDeqlruOf/4SIciTaQkICKtYk9lDX/+oIDpJ/ZmdP/MSIcjTaQkICKt4uF5eVQHgnz3PB0FRBMlARE5alv37ufZj7dw+bhsBvdIi3Q40gxKAiJy1H737kYwcNc5+qnoaKMkICJHZf32Cl5cVsT1p+TSJ6NTpMORZlISEJGj8t9vryctKYHbzhwc6VCkBZQERKTFlmwu5Z01O7jlzEF0TU2KdDjSAkoCItIi1loefHMd3dOSueHUgZEOR1pISUBEWuT9DbtYuGkvd04dQmpyQqTDkRZSEhCRZgsGLb96cz39szpx5YQBkQ5HjoKSgIg026urSlhTUs53zz2epAR1I9FMa09EmqWuPshv3l7PsN7pXDK6b6TDkaOkJCAizTJ70VY279nP96cdT1ycfio62ikJiEiTHait5/fvbWRCblemHN8z0uFIK1ASEJEme+rDTeyqqNEDYzoQJQERaZKy/XX8aX4+5wzvyfjcrEiHI61ESUBEjmhnRTXfe34FFTUBvqcHxnQo+oaHiBxSbSDIU//exB/n5lEbCHLvtGEM690l0mFJK1ISEJFGzVu3k1+8uoZNu6s4Z3hP7r9wBLndUyMdlrSyIyYBY0x/4G9AbyAIzLTW/t4YkwXMBnKBQuAr1tpS464W/R6YDuwHrrfWLm2b8EWktRXsquSXr65h3vpdDOqRyl9vmMBZuhOow2rKkUAA+K61dqkxJh1YYox5B7geeM9a+4Ax5j7gPuBe4AJgqP+bBDzm/4tIO1ZRXcfDc/N48t+bSEmI5/4Lh3Pt5Fx9I7iDO2ISsNaWACX+dYUxZi3QD5gBnOVHexqYj0sCM4C/WWst8LExJtMY08eXIyLtTDBoeWFpEQ++uZ49VTVcPi6be84fRo/05EiHJsdAs64JGGNygZOAT4BeoY7dWltijAkdL/YDtoZNVuSHfS4JGGNuBm4GGDBAP0AlEgnLtpTys1fWsGLrPsYOyOTJ68czKjsz0mHJMdTkJGCMSQNeAO621pYf5osijX1gvzDA2pnATIDx48d/4XMRaTs7y6t58M31vLC0iJ7pyfz2K6O5dEw//QxEDGpSEjDGJOISwLPW2hf94B2h0zzGmD7ATj+8COgfNnk2UNxaAYtIy9UE6nnq34X88b2N1NVbbjtrMLdPGUKangcQs5pyd5ABngDWWmt/G/bRHOA64AH//+Ww4XcYY2bhLgiX6XqASOTNXbeDX7yyhsI9+3XLp3ymKen/VOAaYJUxZrkf9kNc5/8PY8xNwBbgcv/Z67jbQ/Nwt4je0KoRi8gRHaitZ3VxGSu27mO5/ysqPcCgHqk8feNEzjyuR6RDlHaiKXcH/YvGz/MDTG1kfAvcfpRxiUgT1QcteTsrWb61lOVbXce/fkcF9UF3qa1fZifG9M/ktrMGc/m4/rrlUz5HJwJFooi1lpKy6s/t4a/aVsb+2noA0lMSGNM/k28OH8zo7ExG9c+gZ3pKhKOW9kxJQKSd21lRzT8XF7Fsyz5WFO1jV0UNAEnxcQzv24XLx2Uzun8mY/pnktstVXf4SLMoCYi0Yx/l7+Fbzy1jd2UNg7qncvqQ7ozun8no/pkM75NOckJ8pEOUKKckINIOBYOWxz8o4NdvrSO3eyrPfn0Sx/dOj3RY0gEpCYi0M2X76/juP1fw7todXDiqDw9eNkr38UubUcsSaUdWbyvjtmeXULKvmp9ePILrT8nVYxylTSkJiLQD1lpmL9rKT+Z8SrfUJGbfMplxOV0jHZbEACUBkQg7UFvPj19ezfNLijh9aHd+d8UYuqXpFzzl2FASEImgTburuO3vS1i/o4I7pw7lrqlDidctnnIMKQmIRMibq0u4558riY83PHW9nt4lkaEkIHKM1dUH+dWb6/jzgk2Mzs7gkavHkt21c6TDkhilJCByDO0or+aO/1nKosJSrp2cw48uHK4vfElEKQmIHCMf5u/mzueWUVVTz++vHMOMMf0iHZKIkoBIWwsGLY+9n89v3l7PwO6pPPeNkxnaS9/+lfZBSUCkDVVU13H3rOW8t24nF43qwwP69q+0M2qNIm3oRy+tZv6GXfz8kpFcOzlH3/6VdkdPlxBpIy8v38acFcXcPXUo1+nnH6SdUhIQaQPF+w5w//+uZuwA90QvkfZKSUCklQWDlu/+YwX1QctDV4whIV6bmbRfap0irezJf2/io4I9/OSiEeR0S410OCKHpSQg0orWb6/gV2+t55zhvbhiQv9IhyNyREoCIq2kJlDPXbOW0SUlgQcuO1EXgiUq6BZRkVby27c3sG57BU9eP57u+iloiRI6EhBpBR8X7GHmggKumjSAs4f1inQ4Ik2mJCBylMqr6/juP1aQk9WZH00fHulwRJpFp4NEjtJPX/6U7eXVPH/rZFL1kxASZXQkIHIUXl1ZzEvLtnHHlCGcNEDPBJbooyQg0kLby6r50UurGd0/kzvOHhLpcERaRElApAWCQcs9z6+gNhDkd1eMIVHfCpYopZYr0gJPf1TIgo27uf+i4Qzsrm8FS/RSEhBppo07KnjgjXWcPawnV00cEOlwRI6KkoBIM9QGgtw1azmpyfpWsHQMup9NpBl+9+4G1pSUM/OacfRMT4l0OCJHTUcCIk20qHAvf3o/nyvG9+e8kb0jHY5Iq1ASEGmCiuo6vj17OdldO/Pji0dEOhyRVnPEJGCMedIYs9MYszpsWJYx5h1jzEb/v6sfbowxfzDG5BljVhpjxrZl8CLHys9fWUPxvgM8dMUYPSheOpSmHAn8FZjWYNh9wHvW2qHAe/49wAXAUP93M/BY64QpEjlvri7h+SVF3D5lCONy9K1g6ViOmASstR8AexsMngE87V8/DVwaNvxv1vkYyDTG9GmtYEWOtZ3l1fzgxVWc2C+DO6cOjXQ4Iq2updcEellrSwD8/55+eD9ga9h4RX6YSNQJ1Ae55/mVHKir5yF9K1g6qNY+udnYTdO20RGNuRl3yogBA/SFG2kfgkHL0i2lvLKimNdWlbC7spZfzBjJkJ5pkQ5NpE20NAnsMMb0sdaW+NM9O/3wIiD8warZQHFjBVhrZwIzAcaPH99oohA5Fqy1fFpczpwVxby6opjismqSE+KYOrwnl47px7kj9JAY6bhamgTmANcBD/j/L4cNv8MYMwuYBJSFThuJtDcbd1TwyopiXllZwqbdVSTEGc44rgf3TDuec0f01l1AEhOO2MqNMc8BZwHdjTFFwE9xnf8/jDE3AVuAy/3orwPTgTxgP3BDG8Qs0mJb9uznlZXFvLKimHXbK4gzMHlwN245YxDTTuhNZuekSIcockwdMQlYa796iI+mNjKuBW4/2qBEWtP2smpeW1XCnBXFrNi6D4BxOV352cUjmD6qj37+QWKajnelQ6oPWv65eCsvLdvGwsK9WAsj+3bhvguGceGJfeif1TnSIYq0C0oC0uHUBoJ8e/ZyXltVwqAeqdw1dSgXj+7L4B66w0ekISUB6VD21wa45ZklLNi4mx9OH8Y3Th+kn3sWOQwlAekw9u2v5ca/LmL51n08eNmJXDFB3z8RORIlAekQdpZXc80TC9m0u4pHrx7LtBP0ayUiTaEkIFFvy579fO2JT9hdWcOT10/gtKHdIx2SSNRQEpCotm57Odc+sZDa+iDPfn0SJw3Qr3yKNIeSgEStJZtLueGphXRKiucft0zmuF7pkQ5JJOooCUhU+mDDLm55Zgm9uiTzzE2TdN+/SAspCUjUeW1lCXfPXsaQnun87caJ9EhPjnRIIlFLSUCiynMLt/DDl1YxbkBXnrh+AhmdEiMdkkhUUxKQqPHY/HwefHMdZx3fg8euHkenpPhIhyQS9ZQEpN2z1vLAG+t4/IMCLhndl/++fDRJCXrKl0hrUBKQdq0+aPnhi6uYvXgr15ycw88vGUlcnH4GQqS1KAlIu1UTqOfbs5fz+qrtfOvsIXzn3OP0O0AirUxJQNqlqpoAt/7d/RDc/RcO5+unD4p0SCIdkpKAtLlg0FJVG6Cqpp7Kmjoqqg++rqypp7K6jqraeiqqA1TW1FFVU8/qbWXk76rk118exeXj+x95JiLSIkoC0mqstfw7bw9/XlBAUel+KmsCVFYHqKqtb9L0ifGG9JREUpPjyeiUyJ++No7zRvZu46hFYpuSgBw1ay0f5e/hoXc3sKiwlN5dUhiX25W0pATSUhJITU4gPfnzr1OTE0gL/aUkkJocT3KCbvkUOdaUBOSohDr/hZv20qtLMr+YMZIrJvRXhy4SJZQEpEU+KXCd/8cFe+mZnszPLh7BlRMHkJKozl8kmigJSLMsKtzLQ+9s4MP8PfRIT+YnF43gqknq/EWilZKANMmSzXt56J2N/CtvN93Tkrn/wuF87eQcdf4iUU5JQA5r6ZZSHnpnAws27qZbahI/mu46f/1uj0jHoCQgjVq+dR8PvbOB9zfsIis1iR9cMIxrJufQOUlNRqQj0RYtn6kNBFm6pZTH389n3vpddO2cyL3ThnHt5BxSk9VURDoibdkxrKomwNItpSzatJeFhXtZvnUf1XVBMjsncs/5x3PdKbmkqfMX6dC0hceQPZU1LCosZVHhXhYV7uXT4nLqg5Y4AyP7ZnDVxBwmDuzKaUN7qPMXiRHa0jsoay1FpQc+6/AXbtpL/q4qAJIS4jipfybfPGswE3KzGJvTVZ2+SIzSlt+BbN5TxQcbd7Nok+v4S8qqAUhPSWB8TlcuG5fNxNwsTszO0Dd6RQRQEoh6ZQfqeG1lCS8sLWLJ5lIAeqYnM2FgFhNzs5iQm8XxvdOJ14NYRKQRSgJRKFAfZEHebl5YUsTba3ZQGwgytGca910wjGkje5PTrbMeviIiTaIkEEXWb6/ghaVFvLRsG7sqasjsnMhXJ/TnsnHZnNgvQx2/iDSbkkA7t6eyhjkrinlhaRGrt5WTEGeYMqwnl43N5uxhPfXAdRE5KkoC7VBtIMjcdTt5YWkR89btJBC0nNCvCz+9eASXjO5Lt7TkSIcoIh2EkkA7Ya1l1bYyXlhSxJwVxZTur6NHejI3njaQy8Zmc3zv9EiHKCIdUJskAWPMNOD3QDzwF2vtA20xn2hhrWXf/jq2l1e7vzL3tyP8fXk1+/bXkZQQx3kjenHZuGxOH9KdhHid7hGRttPqScAYEw88ApwLFAGLjDFzrLVrWntex1owaKmtD7q/gPur86/Lq+vYXlbD9nLfuZcd7Nx3lFdTEwh+rixjoFtqMn0yUsju2pnxuV0Z2TeD6Sf2IaNTYoSWUERiTVscCUwE8qy1BQDGmFnADKDNk0B90FJZE6CqJuAecu4fdB7++nOf+WH7a+s/69hDnXpNwHX2dWEdfiBomxRHckIcvTNS6NUlhTH9M+mdkULvLimfDeudkULP9GQStZcvIhHWFkmgH7A17H0RMKkN5sPsRVt4/P0CKnzHv7+2vknTJSfEHXzAeVICnZPiSUmMo0tKAonxcSQluL/khDj3PmxYUkLY+7DhqckJ9PGdfUanRN2uKSJRoS2SQGO93xd2oY0xNwM3AwwYMKBFM8pKTWZkvwzSkuNJS04gNTnBde6+gw9/nZqUQHqKG0d74CIiTlskgSKgf9j7bKC44UjW2pnATIDx48c37TxLA+eO6MW5I3q1ZFIREQHaYpd4ETDUGDPQGJMEXAnMaYP5iIjIUWr1IwFrbcAYcwfwFu4W0SettZ+29nxEROTotcn3BKy1rwOvt0XZIiLSenSFVEQkhikJiIjEMCUBEZEYpiQgIhLDlARERGKYsbZF39Nq3SCM2QVsbuHk3YHdRxmCylAZ7TkGlaEyDiXHWtvjqOZurY3qP2CxylAZbVVGe4hBZaiMtvzT6SARkRimJCAiEsM6QhKYqTJURhuW0R5iUBkqo820iwvDIiISGR3hSEBERFqqra88A08CO4HVDYZPBv6Mexzlcv+3AvhS2DjTgPVAHnCfH5YCLMTdUroDeBFY6f82AH8EzgLKgHygGtgTmt6XkQfUAAGg3pfzEpAJvOnHL/FxVwOFwPu45yTMA9YCe4Htfpwa/3+nn+dK4JfAz4CqsDJuCCtjnZ/3dmAf7haxtcA2P+88INeXVwPsBy73y7/alxvwcczx5W0GNvrPD/jy3/BlrQfO93Va4D+r87G96evlq74etgO1fpwg8JsG66TMz7vWr7NP/TKv9/EWA38Ni9P6aVYCY4HpQKWfvs4v86fAv/1y5AG7gL83UkZoOSb7OqnxZWxvUMZm3BPuXvLThMoobVAXoZhrgfIGy7LV19U/GykjtCzTfJ1XhtVnQTPrY5yff9DX6wHg58Cv/bJs9/O83c8n6Kff5udxk/9/wH8WxLWhUBmFQIX/v9bHEAQ+5mDbuN3HGarPUtwjYRurzy1+XrV+/MKw+twatl5LWlifO8Li2Mah29cmH0fAj78hrD73+uF1HGyjjbWvUBl1DZalOW30UGWEt9E9wM/9NhRar5t9md/gYB+22ddvwzb6WR/oy3jWD1+N62MT/XAD/MGPvxIYe8Q++hgkgTP8immYBH4OXAZ0BhL8sD64jjQB9zPU+cAgIMmvyBF+IdOAp3GPrfwUONdP/y6wCpcEXm1sej9ePtAFOA+Y7VfiM7jGWQR82Y9zADjVv+7t4xvry1iJ2/i/juuYi4GlwIPAEtzGUgL8NzDQz2MvMMDXRyc//gbgNuATH8Ny4CNcMlvv52GAK3AbvgHGAEP9uMv88G6+TjbhOv4JuI14H5DsY8j3f5OAM32dTPLLeaWfPs/Xw1DgYV/GZr/MoXVyBS55H/DrJBHXqE/263UH8ARwInAXrlGX+c8/8TFf55flPV/no3wZp/oyNuOS24nAV3AbUVnYciwEzvZlvBM2beh/aFle88vyFVxns6VBXQwC7vGfzW+wLE/jNv6/+TLu8ut5c9iy5AMvALfg2t5o3H3fzamPhbi2kuPX3UV++J24bWE5bsfhOeAC4HHcdrKtQX1MxrXrGuDGsDJ+4aefg+swJgD/wCX5UNuo9svWCXgb+ACXXBqrz/N97AW4Nro8rD43A8fjOqd1Yeu1qfW51ZeZ4evzI2D4IerzEr9eF+B2oj4Nq8/bcNtZha+z0Hpt2L7B6ONqAAAMFUlEQVQu8eWu92WElqU5bfRQZYS30TfDluE8v16fxiWzZ4CuuG2pwE/XsI027MOm+3INrl3cFjb8DT/8ZOCTiN8iaq39ANf5NTQVeNdau99aG/DDUjj4KMrPHlhvra0FZgEzrFvSKlxHuArX4MuNe6hvbyDLT5/Z2PTGmOHAEmttubX2bVyHneLLGoPbMIb69/txKyUPGGitLbHWLvVlrMN3kLjTalm4DSTbl3cabqV1xu0ZbPXlFVlrl+IS1bu4PbOtuEZ6Bu7IZhDw//z/Z60zG7eBnmCtXY5rRPm+vnb6+Y/BJYNSa+0iX0911toaa+0m3J7LLmvtJ9ba932dnO/rsIefPhu401q7EfgvoJevy/B1MtvPswyY4WPf72OZitvL3G6tXYVr2At9vMt8fGnW2qf9uvwLbo9tgC8j4MsAqPBlDPbTJuA6jS1AT2vtXF/G33258WFljPHv9/llGezXR0Z4XeD29KYBz/tlDV+WMT6Orb6MEcBiINNa+zGuvW3DdTYzgf/BbYT7m1kfXf06qMJ1kF/ycXyCa49DfD0FrbVv+GVZzMGdj1B9fITb8AtxHVWojLNxiekpINm3jSxfT+ASQL2vr064zinHr+PG6vMtYAqu80rHtZ1duJ2Cddba9bg91ULg0mbWZxmwwFpb5uuzAviPQ9TnHP/+Udw2mBmqT2vtY7h+Z5+PIbReG7avOX5Z/urL6OHrs2sz2uihyghvo8/52Kzvd+p9fbwMxFlrS3Hb0jNAvwbb6+f6MFwhr/t+weLaU7aPZwbwN//Rx0CmMaYPhxGRawLGmO64zqnMv59kjPkU1/He6pNCYw+s7+dfj8OdVtkJvGOt/QQ4CdeY3/DjjAbGG2PeMMaMDJv+AuBNY0y8MWY58P+BucDpuBWz1o+Xglvhr/r5XRUWywW4J6idBPzGxwFupa7FJZZ0XMcyHLehTsatnGBYGcv9/1m4vdkM3CmZZdbaEtz6GebraCKu4xhtjInHJZALcXtcAdwe4Drchhp6lkOi/wupwh3i4su4Ffixn89yX99xft74/6FyaWSd1AHfCa0HXFJKwe21vBk2TRawzVpbg9sww3cKgriNa1ZYGck+pjfCykgLK6Mcl/hD6/AxH+frvow6H2dCgzK6hS1LqC5+B3wft8ENCluWOlybSWmwLL3DyijDtZlduA72FuAnLawPi9sDfwq4noPteoqP88qwZemCa1/LwuvDf/ZVXFK5rkF9LsMdHYTKyAH2+un74TrL13Cd1yO4o97njlCfQ/3wNzh4iinUPrbhEtH9zazP7cAZxphuvl6nAD89Qn0Oxu2Bv8EX21edr7vwddJY++odVkZ4fULT2+gXymjQRsv8OgXXd6zg8+skVKeh959tr154HwiAMSYRuKZBfRyq32xUpC4Mn4dr8AD4PdORuMPUHxhjUjj8A+vPw53DzAYmGmNOAL6Ja7j34k6zfBN3SuaPwP+GTX8+7hx4Pa4jn4nroDv5cT72847DbWx34ir4MmPMcX6c6biKv9taO8rHkejLCHJwJZ6I61z7+lhuMsZ08Z+dDnwP10CzcXvZnXEN+Gk/ThBI943oW7gGEfCxrwbOxZ26+qVfriS/jM82Unefr0hXxi9xG/9mX07ovDYAxpgpuKTyWmhQI0XNCov/Rtze9CfW2gX+83RgPO6UyecYY9JwpyqWNCgjA9cZhJYjCzihYRnW2npr7RjcacUKXx8TcR3ggAZlZOM6vtfCiugO7LTWLsHVW3FYHNfhEnD4snQHjmukPsbiNvIf404JPNqC+jjVWjsWd92nEjjXt+tbcKc/AmHL0gm3w3FLg/pMAi7GnaJ8JyyGvbhOKwA863eK+uPaf2g5DG77G4jbc96DS/CHq89zcQnnXr7I4k7lPNXM+qzAnVJ9B7d9rMPtiR+uPu/Cba+NxQHu1NaR2tc1jZXRzDb6hTIatNFMv07BHX1+tk78sGzcadpDLQcc7ANDHgU+CKuPw/WbjYpUEriAg5nrM9ba0EWrEzj8A+vPA9621u7Dnce9Abgad1F5j7W2HHcKp791TzlLxDW2XbhDz2JjzE9xh22f+M/fw3X62/y8g7gOscCPtwS3F94FtxH/1Vr7oo9nhh9/oY9tBa4xnw+86A/ZMnAZephPJn2Bv1trX/TLYX0ZBnjbH8JV+XHGANfiNv4lxpjOuL3a3wOv+LKu8XVUjeu48fF/1qkDqbg96tAexPd9zM/jzkNnA8XGmD7GmFG4DbgMd0REI+skESgOWw93+/Kv9fPIxh2RLcF1KuA2liw//xf8/JeGlXGbX54vWWutL+NcXGcQKqOL/wvJ5OApkPm4xJobVsYoXNJdHbYsqbj1eokxphCX7PvhroPMB77myw0tyyjcUd3HYWV0wSXeIr+Hl41rTyObWx/W2lDbTsNdB9qF6yim4dbn1WH1MQh3jS2/QX1cgNsBSsXt0c/HXb85zk9ztV/Gl3xdhJ4sWITrzAuttbtwO1NrcYnmUPV5Fm79X2St3ePnGcfB9pGNa8+FzazPTGvtEz4hPo3bs159mPo8ydfPdB9HFgdPCcMX22hj7WtagzK6AF2a2UYbLSMsjlAbnebfXxNaJw3a6Cw/PYRtr2F1GmonhPVh3wkb53D9ZqOOeRLw5+5H4faQ8Q+kT/Cvc3AXlQo5xAPrjTGDcOc19xhjOuFOiVwFbLDWLvTl9A6b/lLccl6C27DmGWPuxu3NP4nLuttw5/dLcecf5+D2WpJwK+I43B7SWtwGtBF4xhiTaYyZBtzny+6H27Au8WV0B84zxgz05fXBJZVncHuMT/p4b8MllreAvr4RXIe7I+k6X2f/heuQQ+c4u+MO1/viGkqOX6Z5uL16cEkj0RiT7GPoCfQ0xozDnUfvitt7DV0XAHfUdCfu2sTrvl5CPlsnvqwMv0464TqYLGCttXa3MSYTt4f3CP58pTHmZA6ep33Zr+fewMu+jMt9Ha621haFlfFfvox4P+8coNQYc44xpgcHL84X4Dq9TGCNL2OAX5Y7cRtdfFj8NbgN7xS//j7E3alxja+79X5ZQmX8EnfqIbQsO/w63WmMOR3XDgO4i/3NqY9yY8yX/Dg34Npc6BRYOjDFWrs/rIwFQE7Yes3x8X/br79rcUej5/hyevm2keSn/wEuWY0xxiT7uosDRvplvRHXgecdoj7n4HY2dgGbw+qzMzDcGDPJL38urk03pz5zjDHjjTF9cdtADm6ba6w+3/b1vR7YGN6+/OssH/vh2lfo/PzOsGUJ1WdT2+ihygi1UYM7xZcCrDPG/If/fLpfr+Ft9JxGttfP9YG+vr6O226/GnaKGf/5tcY5GXcKqoTDsW1/d9BzuDsfQucE78XtRYc+vwZ3VX85bi/m0rDPpuM2qHzgR37Yd3x5K3F7CEtwh8/bfRmLgTt8mQW4i1VFwI9we3lncfCWstDtdBW4u2oW4zbSfA7euhm65etu3MVe6z9fh9uDCe1t7/DzqsYdVWQBD3DwFrFC3N5QqIwC/9kB/34v7rRM6Hay93BHFftwFy/LcOdHR+HON1o/bahuK/3yr8HtPYVujwvdQrcRt6c43U9jwz4vxR0y/wx3hLGNg7eH1vvpi3B7NtP9/AO+jNqw8feHrYd3/fvQrY+h+Z2Ju+skNG0ohkK/jNVhZSxspIwA7tD6Sg7ephjw06z267IqrIy1YXUYHsdlHGxfW32dlfsyQm0iVMaSQ5Rxpi8jtN7q/DKsaWZ9zPDLHbpFdAfu2sJuP37oFuplYeskVEa+X6+ncrBdh/ae/+TnWeanD7WV8Nt/Q23jTlwnVueHleK2ocbqM3R7dZ0vo5qDbasorIzQOmlufYZvVwW+jMbqMzSfgC/nAG5narwvv2Ebbax9hcpouCzNaaOHKiPURkPb9E98H1YStk5CdVoato6qcYktVKef6wN9GQE/LFRGqGzDwT5sFTD+iH10WyeBRpLC/cCVRzH9X4CTjzTsENMuxd9P25Ry26IM3HnARn81sKUxNHW6I9Tpy0dZxv24C+yRLqM1lqW91Mdi4H7VZ7tqX61Vpy2evrX/9LMRIiIxTD8bISISw5QERERimJKAiEgMUxIQEYlhSgIiIjFMSUBEJIYpCYiIxLD/A90KP/hPuNP7AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "get_case_plot(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Monitoring Large Networks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>Growth of confirmed cases within networks</b>\n",
+    "<br><i>Contact tracing and quarantine recommendations to large networks are important.</i>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<u>Case growth within Network 9:</u> <i>Case growth in Network 9 is seen to be flattening, with the latest case recorded 3/18/20.\n",
+    "This could indicate that the quarantine and preventive measures imposed on this network has been effective. Although we need to wait for more details and contact tracing of new cases to confirm. </i>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First Confirmed Case:  2020-03-09\n",
+      "Latest Confirmed Case:  2020-03-18\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD8CAYAAABn919SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xl4VOXd//H3NxshbAEy7IQ1YRFkCwERg/uCtlZrW6kKCBVba136+FRbu/zsU63WPlZtH6tUEXC3VbvhviCuQNjBhISw7wmQEALZ798fM2CKQCbL5Ewmn9d1zZXJmXPOfOfcmU/OnPvcc8w5h4iINH9RXhcgIiKNQ4EuIhIhFOgiIhFCgS4iEiEU6CIiEUKBLiISIRToIiIRQoEuIhIhFOgiIhEiJhQrTUpKcn379g3FqkVEItKyZcsKnHO+hqwjJIHet29fMjMzQ7FqEZGIZGZbGroOHXIREYkQCnQRkQihQBcRiRAKdBGRCKFAFxGJELUGupkNMrOVNW4Hzey2pihORESCV+tpi8659cBIADOLBnYAr4W4LhERqaO6HnI5D8hzzjX4fEkRkUhRcKiMv6/YwZ8X5nlaR10HFl0NvHCiB8xsFjALIDk5uYFliYiEr4qqapZvOcCi3HwW5RSwZkcRAN3ax3PDWf2Iifame9KCvUi0mcUBO4HTnHN7TjVvWlqa00hREYkk2/Yf5sOcfBbl5PNp3j4OlVUSHWWMTk4kI8XHpEE+hvXoQFSU1Wv9ZrbMOZfWkBrrsod+CbC8tjAXEYkEh8sr+XzjPhblFPBhTj6bCkoA6JnYmq+N6MGkVB8TBnamfXysx5V+qS6BPoWTHG4REWnunHNk7y5mUU4+H+bkk7n5AOVV1cTHRjG+f2emntGHjFQf/ZPaYFa/vfBQCyrQzSwBuAC4MbTliIg0nQMl5Xy0oYBFgUMpe4vLABjUtR3Tz+xLRoqPtL4diY+N9rjS4AQV6M65w0DnENciIhJSlVXVrNxWeOxY+OodRTgHHVrHMjEliUmpPjJSfHTrEO91qfUSkq/PFREJF9sPHGZRjn8v/JO8AopLK4kyGJXckdvOSyUjNYnTeyUSXc/OzHCiQBeRiHKkvIrFm/Yd2wvPy/d3ZvboEM+lw7uTkerjzAFJdEgIn87MxqJAF5FmzTlH7t5DfLg+n0W5+SzetJ/yympaxUQxrn9npqQnMynVx8AubcO2M7OxKNBFpNkpPFzOx8c6MwvYfbAUgJQubbluvP9slHH9OjWbzszGokAXkbBXVe1Yua3QH+C5+azaVki1g/bxMUxMSSIjxUdGqo8eia29LtVTCnQRCUu7io4c2wP/eEMBRUcqMIMRvRK5+dwUJqX6GNGrg2fD7MORAl1EwkJpRRVLNu0/thees+cQAF3bt+LCoV2ZNMjHxIFJJCbEeVxp+FKgi4gnnHPk5R/iw8AphZ9v3EdZZTVxMVGk9+3Et8b0JiPVR2rXyO/MbCwKdBFpMkVHKvh0QwGLcvP5cH0+O4v8nZn9fW347rhkMlJ9jO/XmdZxLaszs7Eo0EUkZKqqHWt2FB0bWr9iWyFV1Y52rWI4c2ASN5/rIyM1iV4dE7wuNSIo0EWkUe05WHrsC64+3lBA4WF/Z+bpPTtw09kDyEj1MbJ3IrHqzGx0CnQRaZCyyioyNx84FuLZu4sB8LVrxXmDu5KRmsRZKT46tVFnZqgp0EWkTpxzbCooORbgn2/cz5GKKuKio0jr25G7LhlMRoqPId3bqTOziSnQRaRWxaUVfJr35fejbD9wBIB+SW34dlovf2dm/860aaVI8ZK2voh8RXW1Y+3OomMDe5ZvPUBltaNtqxjOGNCZGycNYFKKj+TO6swMJwp0EQFgb3EpH+X4Tyn8OLeAfSXlAAzr2Z5ZGf2ZlOpjdJ+O6swMYwp0kRaqvLKazC37j31X+Be7DgKQ1DaOjFQfk1J9TExJIqltK48rlWAp0EVakM0FJSzK9R8H/yxvHyXlVcREGWP6dOQnFw8iI8XH0O7t633levGWAl0kgh0qq+SzvH3Hvh9ly77DACR3SuDK0f7OzDMGdKatOjMjQrAXiU4EngSGAQ6Y4Zz7LJSFiUjdVVc7vth18Nhe+LItB6iociTERTNhQGdmTuxHRoqPvkltvC5VQiDYf8uPAG86564yszhAXdsiYaLgUBkf5wYu9pBbQMEh/5Xrh3Zvz8yJ/clITSKtTyfiYtSZGelqDXQzaw9kANMBnHPlQHloyxKRU1mx9QDvZu1hUU4Ba3YUAdCpTRxnBS72cFZqEl3aNc8r10v9BbOH3h/IB542sxHAMuBW51xJzZnMbBYwCyA5Obmx6xQRIGdPMfe9nsXC9flERxljkjtyx4WpZKT6GNajgzozWzhzzp16BrM04HPgTOfcYjN7BDjonPvFyZZJS0tzmZmZjVupSAuWX1zGQ+/k8NLSrbRtFcPN5w7k6vRk2sdH3pXrWyozW+acS2vIOoLZQ98ObHfOLQ78/jfgroY8qYgE50h5FU9+tJHHP8yjrLKaaRP6csu5KXTUF13JCdQa6M653Wa2zcwGOefWA+cBX4S+NJGWq7ra8eqKHfz+rfXsPljKxad1485LBtNPZ6fIKQR7lsuPgOcCZ7hsBK4PXUkiLdunGwr4zYIsvth1kBG9OvDolFGk9+vkdVnSDAQV6M65lUCDju2IyKlt2FvMb1/P5r3svfRMbM0jV4/ka6f3UEenBE3Dw0Q8VnCojIffzeGFJdtIiI3mrksGM31CX+JjdV1NqRsFuohHSiuqeOrjTfx5YR6lFVVcOy6ZW89P1ZV9pN4U6CJNrLra8Y9VO3jwzfXsLCrlgqFdueuSwQzwtfW6NGnmFOgiTejzjfu4d0EWa3YUMbxnBx76zkjG9+/sdVkSIRToIk0gL/8Qv309m3ez9tCjQzwPf2ckXx+hDk9pXAp0kRDad6iMR97L5bnFW2kdG81/XzSImRP7qcNTQkKBLhICpRVVPP3JZh77YAOHK6r4bnoyt56foqv/SEgp0EUaUXW141+rd/K7N9ezo/AI5w/pwl2XDGZgl3ZelyYtgAJdpJEs2bSfexd8wartRZzWoz0PXnU6EwYmeV2WtCAKdJEG2lRQwv1vZPHWuj10ax/P/35rBFeM6qkOT2lyCnSRejpQUs4j7+Xy7OdbaBUTxR0XpjJzYn9ax6nDU7yhQBepo7LKKuZ9upk/vr+BkrJKrk5P5rbzU3SFIPGcAl0kSM45/r16Fw+8mc32A0c4Z5CPn04eQmpXdXhKeFCgiwQhc/N+frMgi5XbChncrR3PzhzHxBR1eEp4UaCLnMKWfSXc/0Y2b6zdTdf2rfjdVafzzdG9iFaHp4QhBbrICRQeLufR9zbwzOebiY2O4vbzU7khox8JcXrLSPjSX6dIDWWVVTzz2RYefS+XQ2WVfGdsb24/P5Uu7dXhKeFPgS6Cv8Pz9TW7eeDNbLbuP0xGqo+fTR7M4G7tvS5NJGgKdGnxlm89wL0Lsli25QCDu7Vj3ox0JqX6vC5LpM6CCnQz2wwUA1VApXNO1xeVZm/b/sPc/2Y2C1bvwteuFQ98czhXjemtDk9ptuqyh36Oc64gZJWINJGiwxX86YNc5n26hego49bzUpiV0Z82rfSBVZo3/QVLi1FeWc2zn2/h0fdzKTpSwbfG9OLHFwyiWwd1eEpkCDbQHfC2mTngCefc7BDWJNKonHO8tW4397+RzeZ9h5k4MImfTR7C0B7q8JTIEmygn+mc22lmXYB3zCzbObeo5gxmNguYBZCcnNzIZYrUz8pthdy74AuWbj5ASpe2PH39WM5O9WGm4+QSeYIKdOfczsDPvWb2GpAOLDpuntnAbIC0tDTXyHWK1Mm2/Yf53Vvr+deqnSS1jeO+K4bz7bRexERHeV2aSMjUGuhm1gaIcs4VB+5fCPw65JWJ1EPRkQoe+2ADT3+ymago+NG5A7lx0gDaqsNTWoBg/sq7Aq8FPqLGAM87594MaVUidVRRVc3zi7fy8Ls5FB6p4MpRvbjjolS6d2jtdWkiTabWQHfObQRGNEEtInXmnOOdL/Zw/xvZbCwoYcKAzvxs8hCG9ezgdWkiTU6fQ6XZWr29kHsXZLF4034GdmnLnOlpnDOoizo8pcVSoEuzs6PwCA++mc3fV+6kc5s4fvONYVw9trc6PKXFU6BLs1FcWsFjC/N46uNNGHDT2QP4wdkDaBcf63VpImFBgS5hr6KqmheXbOXhd3PZV1LOFaN6csdFg+iZqA5PkZoU6BK2nHO8l7WX376RRV5+CeP6dWLupUMZ3ksdniInokCXsLR2RxH3Lsjis4376J/Uhr9MTeP8IerwFDkVBbqElZ2FR/j92+t5bcUOOibE8evLT2NKejKx6vAUqZUCXcLCobJKHl+Yx18+2ogDbswYwE3nDKC9OjxFgqZAF09VVlXzUuY2/vBODgWHyrl8ZA/uuHAQvTsleF2aSLOjQBdPOOdYuD6f+17PInfvIcb27ciT08Yysnei16WJNFsKdGly63YWcd/rWXyyYR99Oyfw+LVjuOi0rurwFGkgBbo0md1Fpfz+7fW8snw7HVrH8quvDeWacX2Ii1GHp0hjUKBLyJWUVfLEh3nM/mgj1dVww1n9+eE5A+nQWh2eIo1JgS4hU1XteDlzG//7dg4Fh8q47PTu3HnxYHV4ioSIAl1C4sOcfO5bkMX6PcWM6dOR2VPHMDq5o9dliUQ0Bbo0quzdB7l3QRYf5RaQ3CmBx64ZzSXDuqnDU6QJKNClUew5WMpDb+fw12XbaBcfy88vHcJ1Z/ShVUy016WJtBgKdGmQw+WVzF60kSc+3EhldTXXn9mPH507kMSEOK9LE2lxFOhSL1XVjleWbef3b69nb3EZk4d3486LB9OncxuvSxNpsYIOdDOLBjKBHc65y0JXkoS7j3LzuXdBFtm7ixmVnMifrx3NmD6dvC5LpMWryx76rUAW0D5EtUiYW7+7mPtez+LDnHx6d2rNn747ikuHd1eHp0iYCCrQzawXcClwL/DjkFYkYWdvcSl/eCeHl5Zuo22rGO6ePISpE9ThKRJugt1Dfxj4CdAuhLVIGPr36p3c+bfVlFVWM21CX245N4WObdThKRKOag10M7sM2OucW2ZmZ59ivlnALIDk5ORGK1C881FuPre/tJIRvRJ58Fsj6JekDk+RcBbMtyKdCXzdzDYDLwLnmtmzx8/knJvtnEtzzqX5fL5GLlOa2todRXz/mWUM8LVlzvVjFeYizUCtge6c+6lzrpdzri9wNfC+c+7akFcmntmyr4TpTy8hMSGOeTPSddUgkWZC31sq/6HgUBnT5iyhqtoxf2Y6XdvHe12SiASpTgOLnHMLgYUhqUQ8V1JWyYy5S9l9sJTnbxjPAF9br0sSkTrQSFEBoKKqmh88t5x1Ow8y+zp9M6JIc6RDLoJzjjv/tppFOfn89orhnDekq9cliUg9KNCFB95cz6srdvBfF6Ty7bG9vS5HROpJgd7Czfl4E49/mMe145O5+dyBXpcjIg2gQG/B/rVqJ/+z4AsuPq0b93x9mL6TRaSZU6C3UJ9uKOC/Xl7F2D6dePjqkURHKcxFmjsFegu0bmcRs55ZRt+kBP4yNY34WH3JlkgkUKC3MNv2H2b600tpFx/DvBnpdEjQKFCRSKFAb0H2l5Qzbc4SyiurmT8jne4dWntdkog0IgV6C3G43D8KdEfhEZ6alkZKV30TskikUaC3ABVV1fzwueWs3l7Io1NGkdZXl4sTiUQa+h/hnHPc/doaPlifz71XDOOi07p5XZKIhIj20CPcQ+/k8HLmdm49L4VrxvXxuhwRCSEFegR75rPN/PH9DUxJ781t56d4XY6IhJgCPUK9uXYXv/znOs4f0pX/uVyjQEVaAgV6BFq8cR+3vLiSUb0T+eOUUcREq5lFWgK90yNM9u6DfG9+Jr07tuapaWNpHadRoCIthQI9guwoPML0OUtJiItm3ox0OraJ87okEWlCOm0xQhQe9o8CLSmv5K/fP4NeHRO8LklEmpj20CNAaUUVM+dlsnXfYf4yNY3B3dp7XZKIeKDWQDezeDNbYmarzGydmd3TFIVJcCqrqrn5+RUs33qAh68eyfj+nb0uSUQ8EswhlzLgXOfcITOLBT42szecc5+HuDaphXOOX/xjHe9m7eGer5/G5OHdvS5JRDxUa6A75xxwKPBrbODmQlmUBOeR93J5YclWfnjOAKZN6Ot1OSLisaCOoZtZtJmtBPYC7zjnFp9gnllmlmlmmfn5+Y1dpxzn+cVbefjdXK4a04s7LhzkdTkiEgaCCnTnXJVzbiTQC0g3s2EnmGe2cy7NOZfm8/kau06p4e11u/n539dwziAfv71yuEaBighQx7NcnHOFwELg4pBUI7XK3LyfH72wguG9Evm/a0YTq1GgIhIQzFkuPjNLDNxvDZwPZIe6MPmq3D3FzJyXSc/E1jw9fSwJcRpGICJfCiYRugPzzCwa/z+Al51z/w5tWXK8XUVHmDZnCXExUcybkU4njQIVkeMEc5bLamBUE9QiJ1F0pILpc5ZysLSSl24cT+9OGgUqIl+lA7BhrrSiihvmZ7Kx4BCzrxvDaT06eF2SiIQpHYQNY1XVjttfWsmSTft5dMooJgxM8rokEQlj2kMPU8457vnXOt5Yu5tfXDaUr4/o4XVJIhLmFOhh6rGFecz/bAs3ZvRn5sR+XpcjIs2AAj0MvZy5jQffWs8Vo3py58WDvS5HRJoJBXqYeT97Dz99dQ1npSTxwDdPJypKo0BFJDgK9DCyYusBbnpuOUO7t+fP144hLkbNIyLBU2KEibz8Q8yYu5Su7eOZM30sbVvpBCQRqRsFehjYc7CUqU8tITrKmD8jHV+7Vl6XJCLNkHYDPXawtILpTy/lwOFyXpp1Bn06t/G6JBFpprSH7qGyyipunL+M3D3FPH7tGIb30ihQEak/7aF7pLra8eOXV/HZxn384TsjyEjVd8iLSMNoD90Dzjl+/e8vWLB6Fz+bPJgrRvXyuiQRiQAKdA88sWgjcz/dzMyJ/bjhrP5elyMiEUKB3sReWbad+9/I5msjenD35CG6fJyINBoFehNauH4vd76ymgkDOvP7b2kUqIg0LgV6E1m1rZCbnltOStd2PHHdGFrFRHtdkohEGAV6E9hcUMKMuUvp1CaOedePpV18rNcliUgEUqCHWH5xGVPnLMEB82ek06V9vNcliUiEqjXQzay3mX1gZllmts7Mbm2KwiLBobJKrp+7hPziMp6alkZ/X1uvSxKRCBbMwKJK4L+cc8vNrB2wzMzecc59EeLamrXyymp+8OwysnYV8+TUNEYld/S6JBGJcLXuoTvndjnnlgfuFwNZQM9QF9acVVc7fvK3VXyUW8D9Vw7nnMFdvC5JRFqAOh1DN7O+wChg8Qkem2VmmWaWmZ+f3zjVNVP3v5nN31fu5L8vGsS30np7XY6ItBBBB7qZtQVeAW5zzh08/nHn3GznXJpzLs3na7nfS/LkRxuZvWgj087ow01nD/C6HBFpQYIKdDOLxR/mzznnXg1tSc3XP1bu4DcLspg8vBu//NppGgUqIk0qmLNcDHgKyHLOPRT6kpqnj3MLuOOvqxjXrxMPfXsk0RoFKiJNLJg99DOB64BzzWxl4DY5xHU1K2t3FHHjM5kM8LVl9tQ04mM1ClREml6tpy065z4GtLt5Elv3HWb600tJTIhj7vXpdGitUaAi4g1d4KIBCg6VMXXOYiqrq3lxxji6ddAoUBHxjob+11NJWSUz5y5lV1EpT01LY2CXdl6XJCItnAK9HiqqqrnpueWs2VHEn747mjF9OnldkoiIDrnUlXOOO19ZzYc5+fz2yuFcMLSr1yWJiADaQ6+z3721nleX7+D281OZkp7sdTkiIsco0Otg7ieb+PPCPL47LplbzhvodTkiIv9BgR6kBat3cc+/v+DCoV35n8uHaRSoiIQdBXoQPsvbx+0vrWRMckcenTJKo0BFJCwp0GuRtesgs+Zn0qdzAk9O0yhQEQlfCvRT2H7gMNPmLKFNqxjmzUgnMSHO65JERE5KgX4SB0rKmTpnCaUVVcyfmU6PxNZelyQicko6D/0EjpRXMWPeUrYfOMKzM8eR2lWjQEUk/GkP/TiVVdXc/PxyVm0r5NGrR5HeT6NARaR50B56Dc457n5tLe9l7+U33xjGxcO6eV2SiEjQtIdewx/eyeGlzG3ccu5Arh3fx+tyRETqRIEe8MznW3j0/Q18J603t1+Q6nU5IiJ1pkAH3ly7i1/+Yy3nDe7CvVdoFKiINE8tPtCXbNrPLS+uZGTvRP703dHERLf4TSIizVSLTq/1u4v53ryl9OrYmqemjaV1nEaBikjzVWugm9kcM9trZmuboqCmsrPwCNPmLCE+Npp516fTqY1GgYpI8xbMHvpc4OIQ19GkCg/7R4GWlFUy9/p0endK8LokEZEGqzXQnXOLgP1NUEuTKK2o4nvzMtm67zBPTB3D0B7tvS5JRKRRtKiBRVXVjlteWMGyrQf445RRTBiQ5HVJIiKNptE6Rc1slpllmllmfn5+Y6220Tjn+MU/1vL2F3v41WVDuez0Hl6XJCLSqBot0J1zs51zac65NJ/P11irbTR/fH8Dzy/eyg/OHsD0M/t5XY6ISKNrEactvrhkKw+9k8OVo3vyk4sGeV2OiEhIBHPa4gvAZ8AgM9tuZjNDX1bjeeeLPfzstTVMSvXxwDdP1yhQEYlYtXaKOuemNEUhobBsy35ufn45w3t24LFrRhOrUaAiEsEiNuE27C1m5rxMuneIZ870sbRp1aJO6BGRFigiA313USnT5iwlJiqK+TPG0bltK69LEhEJuYgL9KIjFUx/egmFh8uZe/1YkjtrFKiItAwRdRyitKKKWfMzycs/xJzpYxnWs4PXJYmINJmICfSqasePX17J4k37eeTqkZyVEn7nwouIhFJEHHJxznHPv9bx+prd/PzSIVw+sqfXJYmINLmICPTHFuYx/7Mt3HBWP753Vn+vyxER8USzD/S/Zm7jwbfWc/nIHvz0kiFelyMi4plmHegfZO/lrlfXMHFgEg9eNYKoKI0CFZGWq9kG+oqtB7jpueUM6d6Ox68bQ1xMs30pIiKNolmm4Mb8Q8yYuxRfu1Y8PT2dthoFKiLS/AJ9b3EpU+csIcqMeTPS8bXTKFAREWhm56EXl1Ywfc5S9peU88IN4+mX1MbrkkREwkaz2UMvq6zi+88uI2dPMY9dM5oRvRO9LklEJKw0iz306mrHHX9dzScb9vHQt0dw9qAuXpckIhJ2wn4P3TnHbxZk8a9VO7nz4sFcObqX1yWJiISlsA/0v3y0kTmfbGL6hL58f5JGgYqInExYB/prK7Zz3+vZXHp6d3552VBdPk5E5BTCNtAX5eTz339dzfj+nXjo2xoFKiJSm6AC3cwuNrP1ZrbBzO4KdVGrtxfy/WeXMbBLW2ZPTaNVTHSon1JEpNmrNdDNLBr4P+ASYCgwxcyGhqqgzQUlXP/0UjomxDFvRjrt42ND9VQiIhElmD30dGCDc26jc64ceBG4PBTF5BeXMe3pJVQ7x/yZ6XRtHx+KpxERiUjBBHpPYFuN37cHpjWqkrJKZsxdyp6DpTw1fSwDfG0b+ylERCJaMAOLTtQb6b4yk9ksYBZAcnJy3QuJNgb42nDb+SmMTu5Y5+VFRFq6YAJ9O9C7xu+9gJ3Hz+Scmw3MBkhLS/tK4NemVUw0D189qq6LiYhIQDCHXJYCKWbWz8zigKuBf4a2LBERqata99Cdc5VmdjPwFhANzHHOrQt5ZSIiUidBfTmXc+514PUQ1yIiIg0QtiNFRUSkbhToIiIRQoEuIhIhFOgiIhFCgS4iEiHMuTqPAap9pWb5wJZ6Lp4EFDRiOdJwapPwpHYJPw1pkz7OOV9Dnjwkgd4QZpbpnEvzug75ktokPKldwo/XbaJDLiIiEUKBLiISIcIx0Gd7XYB8hdokPKldwo+nbRJ2x9BFRKR+wnEPXURE6qHegW5m8Wa2xMxWmdk6M7unxmNTzOxuM+toZq+Z2erAvMOOW8cTZnammT1oZtmB+V4zs8Qa8/w0cHHq9WZ2UWBabzP7wMyyAs99a435O5nZO2aWG/gZ0VfLCLIdBpvZZ2ZWZmZ3HLf8HDPba2ZrT7DuM8zsL2Z2gZktM7M1gZ/n1phnTGD6BjN71MwsML1ObRppGtIup1r2uOWvCWzf1Wb2qZmNqDHPCS/sbmbPBaavDbR9bGC6BdpvQ2B9o0O7hZpeI7xXbg8st9bMXjCz+BMs722bOOfqdcN/JaO2gfuxwGJgfOD3ecAY4EHgV4Fpg4H3jlvHSvxfyXshEBOY9gDwQOD+UGAV0AroB+QF5u8OjA7M0w7IAYYGfv8dcFfg/l1H1xWptyDboQswFrgXuOO45TOA0cDaE6z7HuCbwCigR2DaMGBHjXmWAGcE6ngDuCQwvU5t6vV2DKd2OdWyxy0/AegYmHYJsDhwPzqwXfsDcYHtffT9MTmwfgNeAH5QY/obgenjj64rkm4NbJOewCagdeD3l4Hp4dYm9d5Dd36HAr/GBm4usIc2EliO/837XmD+bKCvmXUFMLMhQI5zrso597ZzrjKwrs/xXxUJ/BejftE5V+ac2wRsANKdc7ucc8sD6y0GsvjyOqeXBzbu0Y38jfq+xuYgmHZwzu11zi0FKk6w/CJg/0lWfx7wrnNuhXPu6FWq1gHxZtbKzLoD7Z1znzn/X+B8Atu7rm1a/y0QnhrSLidbFvx7bTWW/9Q5dyAwX81tfNILuzvnXg+s3+H/Z1yzXeYHHvocSAy0b8Ro6HsF/9eNtzazGCCBwJXbwqlNGnQM3cyizWwlsBd4xzm3GP/e3KpAcauAKwPzpgN9ahR7CfDmCVY7A/9/JQjiAtVm1jfwnIsDk7o653YBBH52qf8rbB6CaIf6rDMJqHDOFR330DeBFc65Mvxtsb3GYye7gHid2jRSNKRdTrIsp1h+JnV738QC1/Hle7BFtEt928Q5twP4PbAV2AUUOefeDjwcNm3SoEAP7F2PxB/S6eY/Rn4xX76I+4GOgQ34I2AFcHSv7SKOC3QzuzsHSKEvAAADCUlEQVTw+HNHJ53oaWvM3xZ4BbjNOXewIa+lOQuiHerjQuDtmhPM7DT8h09uPDrpROUct0yd2jSSNKRdTrIsJ1rezM7BHx53Hp10olUe9/tjwCLn3Ed1WKbZq2+bmL8v7nL8hwl7AG3M7NrAw2HTJo1ylotzrhBYiP+FHQsC59xB59z1gQ04FfABm8wsAUis8TEeM5sGXAZcU+M/3UkvUB34b/YK8Jxz7tUa8+w5+rEk8HNvY7zG5uBk7VBP//EJysx6Aa8BU51zeYHJ2/nyExccdwHxurZppGpIuxy3LMcvb2anA08Clzvn9gUmn3Ibm9mv8L8Xf1xjnhbVLvVok/OBTc65fOdcBfAq/uPlHL+8l23SkLNcfBY4c8HMWuN/wbn4O8L2BaYnmv/C0gDfw//f5yBwDvBBjXVdjP8/2dedc4drPM0/gasDx2v7ASnAksAxq6eALOfcQ8eV9k9gWuD+NOAf9X2NzUEw7VCPdRpwOv5OawLrXwD81Dn3ydH5Aoe0is1sfGCZqQS2d13btD51hrOGtMtJls02sw785/srGX+wXOecy6mxipNe2N3Mvof/0/EU51x1jWX+CUwNnFkxHv8hhV0N3AxhpYHvla3AeDNLCPytnwdkhV2buPr3GJ+O/xDKamAt8EvgKuD/1ZjnjMAGyw68yKO9v38Czq4x3wb8x4pWBm6P13jsbvy9w+v58gyKifg/eqyusczkwGOd8XfE5gZ+dqrva2wOtyDboRv+//YHgcLA/faBx17Af0ywIjB9JpAGzK2x/M+BkhrbeiXQJfBYWuB58wLtenSwWp3aNNJuDWmXEy0bmP/45Z8EDtTYxpk1HpuM/+yvPODuGtMrA9OOLnN03Qb8X+CxNUCa19swnNok8Ng9+LNsLfAM/jO1wqpNGnWkqJk9CTzp/D2yp5pvOTDO+T+6SCMLth1OsfzP8ffIv9i4lbVsjdAuDVpevirS2kRD/0VEIoSG/ouIRAgFuohIhFCgi4hECAW6iEiEUKCLiEQIBbqISIRQoIuIRIj/D1Oi74qkz1KRAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "get_case_plot(df[df['case_no_int'].isin(comp_list[9])])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<u>Case growth within Network 6</u>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First Confirmed Case:  2020-03-08\n",
+      "Latest Confirmed Case:  2020-03-10\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD8CAYAAABn919SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAH/hJREFUeJzt3Xd8VfX9x/HXNxAgYYQVNiHsMBJW2E5cIC7EVq11K9Zfbe3PVojgQAEFtVVbtRQ3dVVJEGSLCxVEQCGLACHsFWYSyM79/v7I9VdKgdxAwrn33Pfz8bgP7zjn5H0F3jk5OedzjbUWEREJfCFOBxARkaqhQhcRcQkVuoiIS6jQRURcQoUuIuISKnQREZdQoYuIuIQKXUTEJVToIiIuUbM6Ntq0aVMbHR1dHZsWEXGlNWvWHLDWRp7NNqql0KOjo1m9enV1bFpExJWMMdvOdhs65CIi4hIqdBERl1Chi4i4hApdRMQlVOgiIi7h01kuxpitQB5QBpRaa+OrM5SIiFReZU5bvNhae6DakoiIyFnRIRcRkSqwaushpn+92dEMvha6BZYYY9YYY8acbAFjzBhjzGpjzOr9+/dXXUIRET92tKiUx+ek8ovpK3h/5Xbyi0sdy+LrIZeh1trdxphmwGfGmAxr7bLjF7DWzgBmAMTHx+uTp0XE9b7euJ/xSSnszingzqHR/OnyroTXqpYL8H3i01e21u72/jfbGDMbGAAsO/1aIiLudPhYMZPmp5P04y46NavHrN8MoV+7Rk7HqrjQjTF1gRBrbZ73/uXAU9WeTETEz1hrWZi6l8fnpHIkv4TfDevEA8M6UbtmDaejAb7toTcHZhtjfl7+fWvtompNJSLiZ7JzC3lsTiqL0/YR2zqCmXcNpHurBk7H+g8VFrq1NgvodQ6yiIj4HWstH6/ZyeR56RSVekgYEcM957WnZg3/O0nQuaP3IiJ+bsehfB5JSuHbzAMMiG7M1NGxdIis53SsU1Khi4icoMxjeWf5Vp5bvIEaIYZJ1/XklgFRhIQYp6OdlgpdROQ4m/blMS4xmR+3H+GirpE8PSqWVg3DnI7lExW6iAhQUuZh+leb+dsXmdStXYMXb+zNtb1b4T0hJCCo0EUk6KXszOHhWevI2JvHVXEtmXhND5rWq+10rEpToYtI0CosKeOFpRt5bVkWTevVZsat/bi8RwunY50xFbqIBKWVWQdJSEphy4Fj3DygLQkjuhERFup0rLOiQheRoJJXWMK0RRm8+/12ohqH8/49AxnSqanTsaqECl1EgsaXGdmMn53CvtxC7jmvPQ9d3sXRYVpVzT3vRETkFA4dK+apT9P4ZO1uOjerx6v3D6FPlPPDtKqaCl1EXMtay7zkPUycm0ZOQQkPXtKZ/7m4o98M06pqKnQRcaV9uYVMmJ3K0vX7iGsTwXv3DiSmhX8N06pqKnQRcRVrLf9atYMpC9ZTUuZhwpXduHNotF8O06pqKnQRcY1tB4/xSFIKyzcfZFCHxky9Po7opnWdjnXOqNBFJOCVeSxvfbeF55dsIDQkhKdHxXJT/7Z+P0yrqqnQRSSgbdibx9jEZNbtOMIlMc2YPKonLSMCY5hWVVOhi0hAKi718OpXmbzyZSb164Ty0k29uaZXYA3TqmoqdBEJOOt2HGHsrGQ27Mvj2t6tePyq7jQJwGFaVU2FLiIBo6C4jL98toE3vt1Cs/p1eOP2eC7p1tzpWH5DhS4iAWH55gMkJKaw/VA+vxoYRcKIGBrUCexhWlVNhS4ifi23sIRnFmTwwQ/badcknA/uHcTgjk2cjuWXVOgi4reWpu9jwicp7M8rYswFHfjfS7sQVsudl+1XBRW6iPidg0eLePLTdOau201Mi/rMuDWeXm0bOh3L76nQRcRvWGuZu243E+emcbSolIcu68JvLuxIrZruv2y/KqjQRcQv7Mkp4NHZqXyekU3vtg159oY4ujSv73SsgKJCFxFHeTyWD1Zt55kFGZR5LI9d1Z07hkRTI8gu268KKnQRccyWA8dISExm5ZZDDO3UhGdGxRHVJNzpWAFLhS4i51xpmYc3v9vCn5dspFbNEKaNjuWX8W2D+rL9qqBCF5Fzav2eXMYlJpO8M4fLujdn8nU9ad6gjtOxXEGFLiLnRFFpGa98kcmrX20mIiyUl3/Vh5GxLbVXXoV8LnRjTA1gNbDLWntV9UUSEbf5cfthxs1KZlP2Ua7v05rHrupOo7q1nI7lOpXZQ38QWA+4+0P5RKTK5BeX8vzijby1fAstG9ThrTv7c3HXZk7Hci2fCt0Y0wYYCUwBHqrWRCLiCt9lHiAhKZkdhwq4dVA7xg7vSn0N06pWvu6hvwiMBXSWv4icVk5BCU/PX8+/Vu+gfdO6/GvMIAZ20DCtc6HCQjfGXAVkW2vXGGMuOs1yY4AxAFFRUVUWUEQCx5K0vTz6SSoHjxXzmws78odLO1MnVMO0zhVf9tCHAtcYY64E6gANjDHvWmt/ffxC1toZwAyA+Ph4W+VJRcRv7c8rYuKnacxP3kO3lg144/b+xLaJcDpW0Kmw0K21jwCPAHj30P90YpmLSHCy1jL7p108NS+d/KIyHr6iK2Mu6EBoDQ3TcoLOQxeRM7LrSAETZqfw1Yb99I0qH6bVqZl+zeakShW6tfYr4KtqSSIiAcHjsby3chtTF2ZggYlXd+fWwRqm5Q+0hy4iPsvaf5SExBR+2HqI8zs35elRsbRtrGFa/kKFLiIVKi3z8No3W3hh6Ubq1AzhuRviuKFfG12272dU6CJyWmm7cxiXmEzqrlyG92jBU9f2oJmGafklFbqInFRhSRl/+2IT07/OolF4Lf5+S19GxLZ0OpachgpdRP7Lmm2HGDsrmc37jzG6bxseu6obDcM1TMvfqdBF5P8dKyrlucUbeGfFVlpFhPHOXQO4sEuk07HERyp0EQFg2cb9PJKUwu6cAm4b1I6Hh8dQr7YqIpDoT0skyB3JL2by/PXMWrOTDpF1+fi+wcRHN3Y6lpwBFbpIEFuYsofH5qRxOL+Y317ckd8N0zCtQKZCFwlC2XmFPDEnjYWpe+nRqgHv3NWfHq00TCvQqdBFgoi1lllrdjJ5/noKSsoYO7wr956vYVpuoUIXCRI7DuUzfnYK32w6QP/oRkwdHUfHyHpOx5IqpEIXcTmPxzJzxVaeXbwBAzx1bQ9+PbAdIRqm5ToqdBEXy8w+SkJiMqu3HebCLpFMGdWTNo00TMutVOgiLlRS5mHGsixeWrqJ8No1+MsvezGqT2sN03I5FbqIy6TuymHsrGTS9+QyMrYlE6/pQWT92k7HknNAhS7iEoUlZbz0+SZmLMuicd1aTP91P4b3bOF0LDmHVOgiLrBq6yHGzUom68AxfhnfhglXdiciPNTpWHKOqdBFAtjRolKeXZTBzBXbaNMojHfvHsh5nZs6HUscokIXCVBfbshmQlIKe3ILuWtoe/54eRfqaphWUNOfvkiAOXysmEnz0kn6aRedmtVj1m+G0K9dI6djiR9QoYsECGstC1L28sTcVI7kl/D7YZ347bBO1K6pYVpSToUuEgCycwt59JNUlqTvI7Z1BDPvGkj3Vg2cjiV+RoUu4sestXy8eieT5qdTXOrhkREx3H1ee2pqmJachApdxE9tP1g+TOvbzAMMaN+YqdfH0kHDtOQ0VOgifqbMY3l7+VaeX7yBGiGGydf15FcDojRMSyqkQhfxI5v25TE2MZmfth/h4q6RTBkVS6uGYU7HkgChQhfxA8WlHqZ/vZmXv8ikbu0avHhjb67t3UrDtKRSVOgiDkveeYSxs5LJ2JvH1b1a8cTV3WlaT8O0pPJU6CIOKSgu48WlG3ntmywi69fmtdviuax7c6djSQBToYs44PusgyQkJrP1YD43D2hLwohuRIRpmJacnQoL3RhTB1gG1PYuP8ta+0R1BxNxo7zCEqYuzOC9lduJahzO+/cMZEgnDdOSquHLHnoRMMxae9QYEwp8a4xZaK39vpqzibjKFxn7mDA7lX25hdxzXnv+eHlXwmrpsn2pOhUWurXWAke9D0O9N1udoUTc5NCxYp76NI1P1u6mS/N6vHrLEPpEaZiWVD2fjqEbY2oAa4BOwCvW2pUnWWYMMAYgKiqqKjOKBCRrLZ8m72Hi3DTyCkt48JLO/PbiTtSqqcv2pXr4VOjW2jKgtzGmITDbGNPTWpt6wjIzgBkA8fHx2oOXoLY3p3yY1tL1++jVJoJpNwwkpoWGaUn1qtRZLtbaI8aYr4DhQGoFi4sEHWstH67awdPz11Pi8fDoyG7cObQ9NXTZvpwDvpzlEgmUeMs8DLgUmFbtyUQCzLaDx0hITGFF1kEGd2jC1NGxtGtS1+lYEkR82UNvCbzjPY4eAnxkrZ1XvbFEAkeZx/LWd1t4fskGQkNCeOb6WG7q31aX7cs558tZLslAn3OQRSTgbNhbPkxr3Y4jXNqtGZOvi6VFRB2nY0mQ0pWiImeguNTDK19m8upXmdSvE8pfb+7D1XEttVcujlKhi1TS2h1HGDtrHRv3HeXa3q144uoeNK5by+lYIip0EV8VFJfx5yUbePO7LTSrX4c3bo/nkm4apiX+Q4Uu4oPlmw+QkJjC9kP53DIwioQRMdSvo2Fa4l9U6CKnkVtYwjML1vPBDzuIbhLOh2MGMahDE6djiZyUCl3kFJam72PCJynszyvivgs68IdLu2iYlvg1FbrICQ4cLeLJT9P5dN1uYlrU57Xb4olr09DpWCIVUqGLeFlrmbN2N09+msbRolIeuqwLv7mwo4ZpScBQoYsAu48U8OgnqXyRkU2fqIZMGx1Hl+b1nY4lUikqdAlqHo/l/R+2M3VhBmUey+NXdef2IdEapiUBSYUuQWvLgWMkJCazcsshhnZqwjOj4ohqEu50LJEzpkKXoFNa5uGNb7fwl882UqtmCM+OjuMX8W102b4EPBW6BJX03bmMS0wmZVcOl3VvzuTretK8gYZpiTuo0CUoFJWW8fIXmfz9q800DA/llV/15crYFtorF1dRoYvrrdl2mHGJyWRmH+X6vq15bGR3GmmYlriQCl1cK7+4lOcWb+Dt5Vtp2aAOb93Zn4u7NnM6lki1UaGLK3276QAJScnsPFzAbYPbMXZ4DPVq66+7uJv+hour5OSXMGVBOh+t3kn7pnX56L7BDGjf2OlYIueECl1cY1HqXh6bk8qhY8Xcf1FHHrykM3VCNUxLgocKXQLe/rwiJs5NY37KHrq3bMBbd/SnZ+sIp2OJnHMqdAlY1lqSftzFU/PSKSgu4+ErujLmgg6E1tAwLQlOKnQJSLuOFDA+KYWvN+6nX7tGTBsdR6dm9ZyOJeIoFboEFI/H8u7KbUxbmIEFJl7dndsGRxOiYVoiKnQJHJv3HyUhMZlVWw9zfuemPD0qlraNNUxL5GcqdPF7JWUeXvsmixeXbqJOzRCeuyGOG/ppmJbIiVTo4tdSd+UwLjGZtN25jOjZgiev7UGz+hqmJXIyKnTxS4UlZfzti01M/zqLRuG1+PstfRkR29LpWCJ+TYUufmf11kOMTUwma/8xbujXhkdHdqNhuIZpiVREhS5+41hR+TCtd1ZspVVEGDPvGsAFXSKdjiUSMFTo4he+3rif8Ukp7M4p4PbB0Tx8RVfqapiWSKVU+C/GGNMWmAm0ADzADGvtS9UdTILDkfxiJs1bT+KPO+kYWZeP7xtMfLSGaYmcCV92gUqBP1prfzTG1AfWGGM+s9amV3M2cbmFKXt4bE4ah/OLeeDiTjwwrJOGaYmchQoL3Vq7B9jjvZ9njFkPtAZU6HJGsnMLeXxOGovS9tKjVQPeuas/PVppmJbI2arUQUpjTDTQB1hZHWHE3ay1zFqzk0nz0iks9TBueAz3nt+emhqmJVIlfC50Y0w9IBH4g7U29ySvjwHGAERFRVVZQHGHHYfyGT87hW82HaB/dCOmjo6jY6SGaYlUJZ8K3RgTSnmZv2etTTrZMtbaGcAMgPj4eFtlCSWglXksM1ds5bnFGzDApGt7cMvAdhqmJVINfDnLxQBvAOuttX+p/kjiFpnZeYxLTGHNtsNc2CWSp6+PpXXDMKdjibiWL3voQ4FbgRRjzFrvc+OttQuqL5YEspIyD//4ejN//TyT8No1+MsvezGqT2sN0xKpZr6c5fItoH+J4pPUXTk8PCuZ9XtyGRnXkolX9yCyfm2nY4kEBV2KJ1WisKSMF5du4rVvsmhctxb/uLUfV/Ro4XQskaCiQpeztjLrIAlJKWw5cIwb49sy/spuRISHOh1LJOio0OWM5RWW8OyiDfzz+220aRTGu3cP5LzOTZ2OJRK0VOhyRr7ckM2EpBT25BZy19D2/OmKLoTX0l8nESfpX6BUyuFjxUyal07ST7vo3KweifcPoW9UI6djiQgqdPGRtZb5KXt4Yk4aOQUl/H5YJ347rBO1a2qYloi/UKFLhfblFvLoJ6l8lr6P2NYRvHvPQLq1bOB0LBE5gQpdTslay0erdzB5/nqKSz08MiKGu8/TMC0Rf6VCl5PafjCfhKRklm8+yID2jZk2Oo72Tes6HUtETkOFLv+hzGN5e/lWnl+8gRohhimjenJz/ygN0xIJACp0+X8b9+UxdlYya3ccYVhMM6aM6knLCA3TEgkUKnShuNTD9K8387cvNlGvdk1euqk31/RqpWFaIgFGhR7k1u04wrjEZDL25nF1r1ZMvLo7TeppmJZIIFKhB6mC4jJeWLqR17/JIrJ+bV67LZ7Lujd3OpaInAUVehBasfkgjyQls/VgPjcPiOKRK2NoUEfDtEQCnQo9iOQWljB1YQbvr9xOuybhvH/vQIZ01DAtEbdQoQeJLzL2MT4pley8Qu49vz0PXdaVsFq6bF/ETVToLnfwaBFPzUtnztrddG1en+m39qN324ZOxxKRaqBCdylrLXPX7ebJT9PJKyzhD5d25n8u6kStmrpsX8StVOgutCengEdnp/J5Rja92jbk2dFxdG1R3+lYIlLNVOgu4vFYPly1g2cWrKfE4+HRkd24c2h7auiyfZGgoEJ3ia0HjpGQlMz3WYcY3KEJU0fH0q6JhmmJBBMVeoAr81je/HYLf/5sA6EhIUy9PpYb+7fVZfsiQUiFHsAy9uYyblYy63bmcGm3Zky+LpYWEXWcjiUiDlGhB6Ci0jJe+XIzr36ZSURYKH+7uQ9XxbXUXrlIkFOhB5ifth9mXGIyG/cd5brerXj86h40rlvL6Vgi4gdU6AEiv7iUPy/ZyJvfbaFFgzq8eUc8w2I0TEtE/k2FHgCWZx4gISmF7Yfy+fWgKMYNj6G+hmmJyAlU6H4sp6CEZxas58NVO4huEs6HYwYxqEMTp2OJiJ9SofupJWl7efSTVA4cLeK+Czvwv5d2oU6ohmmJyKmp0P3MgaNFTJybxrzkPcS0qM/rt8cT10bDtESkYhUWujHmTeAqINta27P6IwUnay2frN3Fk5+mk19Uxh8v68J9F3bUMC0R8Zkve+hvAy8DM6s3SvDafaSACbNT+HLDfvpElQ/T6txcw7REpHIqLHRr7TJjTHT1Rwk+Ho/lvR+2M21hBmUey+NXdef2IdEapiUiZ6TKjqEbY8YAYwCioqKqarOulbX/KAlJKfyw5RDndWrKM9fH0rZxuNOxRCSAVVmhW2tnADMA4uPjbVVt121Kyzy8/u0WXvhsI7VqhvDs6Dh+Ed9Gl+2LyFnTWS7nUPruXMYmriN1Vy6Xd2/OpOt60ryBhmmJSNVQoZ8DRaVlvPxFJn//ajMNw0N59Za+jOjZQnvlIlKlfDlt8QPgIqCpMWYn8IS19o3qDuYWa7aVD9PKzD7K9X1b89jI7jTSMC0RqQa+nOVy87kI4jbHikp5fskG3l6+lVYRYbx9Z38u6trM6Vgi4mI65FINvtm0n0eSUth5uIDbBrdj7PAY6tXW/2oRqV5qmSqUk1/C5PnpfLxmJx2a1uWj+wYzoH1jp2OJSJBQoVeRRal7eWxOKoeOFXP/RR158JLOGqYlIueUCv0sZecVMnFuGgtS9tK9ZQPeuqM/PVtHOB1LRIKQCv0MWWtJ+nEXT81Lp6CkjIev6MqYCzoQWkPDtETEGSr0M7DzcD7jZ6eybON++rVrxLTRcXRqVs/pWCIS5FToleDxWP75/TamLcoA4MlrenDroHaEaJiWiPgBFbqPNu8/yrhZyazedpjzOzfl6VEapiUi/kWFXoGSMg8zlmXx0uebCAutwfO/6MXovq112b6I+B0V+mmk7sphXGIyabtzuTK2BROv6UGz+hqmJSL+SYV+EoUlZfz18038Y1kWjcJrMf3XfRnes6XTsURETkuFfoJVWw8xLjGZrP3H+EW/Njw6sjsR4aFOxxIRqZAK3etoUSnPLspg5opttG4Yxsy7BnBBl0inY4mI+EyFDny9cT/jk1LYnVPAHUOiefiKrtTVMC0RCTBB3VpH8ot5al46ST/uomNkXT6+bzDx0RqmJSKBKWgLfUHKHh6fk8qR/BIeuLgTDwzrpGFaIhLQgq7Qs3MLeWxOKovT9tGzdQPeuWsAPVppmJaIBL6gKXRrLR+v2cnkeekUlnoYNzyGe89vT00N0xIRlwiKQt9xKJ9HklL4NvMAA6IbM3V0LB0iNUxLRNzF1YVe5rHMXLGVZxdtIMTApGt7cMtADdMSEXdybaFnZucxdlYyP24/wkVdI5kyKpbWDcOcjiUiUm1cV+glZR7+8fVm/vp5JuG1a/DCjb24rreGaYmI+7mq0FN25vDwrHVk7M1jZFxLnrymB03r1XY6lojIOeGKQi8sKeOFpRt5bVkWTevV5h+39uOKHi2cjiUick4FfKGvzDpIQlIKWw4c48b4towf2Y2IMA3TEpHgE7CFnldYwrRFGbz7/XbaNg7jvXsGMrRTU6djiYg4JiAL/cuMbCbMTmFPbiF3n9eeP17ehfBaAflWRESqTEC14KFjxUyal87sn3bRuVk9Eu8fQt+oRk7HEhHxCwFR6NZa5iXvYeLcNHIKSvj9JZ357cUdqV1Tw7RERH7m94W+L7eQCbNTWbp+H3FtInj3noF0a9nA6VgiIn7Hp0I3xgwHXgJqAK9ba6dWayrK98r/tWoHUxasp7jUw/grY7hrqIZpiYicSoWFboypAbwCXAbsBFYZY+Zaa9OrK9T2g/kkJCWzfPNBBrZvzLTRcUQ3rVtdX05ExBV82UMfAGRaa7MAjDEfAtcCVV7oZR7LW99t4fklG6gZEsKUUT25uX+UhmmJiPjAl0JvDew47vFOYGBVB8nJL+H2t35g7Y4jDItpxpRRPWkZoWFaIiK+8qXQT7Z7bP9rIWPGAGMAoqKiKh2kQVhN2jUJ586h0VzTq5WGaYmIVJIvhb4TaHvc4zbA7hMXstbOAGYAxMfH/1fhV8QYw0s39ansaiIi4uXLKSOrgM7GmPbGmFrATcDc6o0lIiKVVeEeurW21BjzALCY8tMW37TWplV7MhERqRSfzkO31i4AFlRzFhEROQu6SkdExCVU6CIiLqFCFxFxCRW6iIhLqNBFRFzCWFvpa4Aq3qgx+4FtZ7h6U+BAFcYRETlXzqa/2llrI8/mi1dLoZ8NY8xqa2280zlERCrL6f7SIRcREZdQoYuIuIQ/FvoMpwOIiJwhR/vL746hi4jImfHHPXQRETkDZ1zoxpg6xpgfjDHrjDFpxpgnj3vtZmPMBGNMhDHm0+OWufOEbSwyxrQ2xrxnjNlgjEk1xrxpjAn1vm6MMX81xmQaY5KNMX29z/c2xqzwbjPZGHPjcdtsb4xZaYzZZIz5l3fkr4gEOR87K8bbLUXGmD+dsP5wb09lGmMSTnjt5/Vv8XZSsjFmuTGmV0XrV7b/Tstae0Y3yj/JqJ73fiiwEhjkffwO0A8YD0zzPhcJHAJqeR+HAT9471/p3Z4BPgDuP+75hd7nBwErvc93ATp777cC9gANvY8/Am7y3p/+87Z000234L752FnNgP7AFOBPx61bA9gMdABqAeuA7se9/vP6Q4BG3udGHNdZp1y/sv13utsZ76Hbcke9D0O9N2vKPzuuN/Aj5R9VV9/7XD3KC73Uu85FwFfebS3wbs8CP1D+qUhQ/mHUM70vfQ80NMa0tNZutNZu8q67G8gGIr1fZxgwy7v+O8B1Z/oeRcQ9fOksa222tXYVUHLC6gOATGttlrW2GPiQ8n7ihPWXW2sPe9f5nn932SnXr2z/ne49ntUxdGNMDWPMWsoL9TNr7UqgD7DOG+5loBvlH1mXAjxorfV4Vx8BLDphe6HArcc9f7IPqG59wjoDKP+OtxloAhyx1paeankRCV4+dNapnK6LTrX+3ZTvYVe0/s/ZKt1/JzqrQrfWlllre1P+HWWAMaYnMJx/v4krgLWUHxbpDbxsjGngfW0o8O0Jm3wVWGat/cb7+LQfUO39bvVP4E7vNwqfPtBaRIKTD511Kqfrlv9a3xhzMeWFPs6H9X9Wqf47mSo5y8Vae4TywyfDgcuBJd6X7gSSvD8yZAJbgBhjTAdgh/dHDwCMMU9Qfpz9oeM2fcoPqPZ+Y5gPPOr9cQTKZyg0NMbUPHF5EZGfnaazTuWUXXTi+saYOOB14Fpr7UEf1q90/53K2ZzlEmmMaei9HwZcCmwCah73JrYDl3iXaQ50BbI44XCLMeYeyvfmbz7ukAyUfxj1bd7f9g4Ccqy1e7xnrsym/PjSxz8v7P2R50vgBu9TtwNzzvQ9ioh7+NhZp7IK6Ow9i64WcBMw1xgTcfz6xpgoIAm41Vq7saL1vetUqv9OF9KnzxQ9hZbAO8aYGpR/Y/iI8l8yLD1umUnA28aYFMp/fBhnrT1gjBkO/O645aZTPp1xRfnvF0iy1j5F+eeYXglkAvmU7/ED/BK4AGhijLnD+9wd1tq1lP+I86ExZjLwE/DGWbxHEXGPCjvLGNMCWA00ADzGmD9QfjZKrjHmAWAx5WesvGmtTTPG3MB/dt7jlP8u71Vvl5Vaa+OttaUnW9+7TmX775Sq9EpRY8zrwOvHHQI52TK1ge+sJiqKiMN86azqXL+q6dJ/ERGX0KX/IiIuoUIXEXEJFbqIiEuo0EVEXEKFLiLiEip0ERGXUKGLiLjE/wEsUhSJCvTPrQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "get_case_plot(df[df['case_no_int'].isin(comp_list[6])])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<u>Case growth among contacts of PH43:</u><i> No new cases among contacts of PH43 since 3/13/20</i>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First Confirmed Case:  2020-03-09\n",
+      "Latest Confirmed Case:  2020-03-13\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAD8CAYAAABw1c+bAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xl4VPXZ//H3DQn7DmEnBGUHWcPeWrUuuKIVFbQqQcW1rX2qre1TtbXLo11/1qVKlQRcwA1b6lprbdWwJez7IgkQCDskBLLn/v0xQ5vGAAmZZJLM53VdczFz5nvO3AnffObk5Mx9zN0REZHI0SDcBYiISM1S8IuIRBgFv4hIhFHwi4hEGAW/iEiEUfCLiEQYBb+ISIRR8IuIRBgFv4hIhIkK1wt36NDB4+LiwvXyIiJ10rJlyw64e0xVthG24I+LiyM1NTVcLy8iUieZ2faqbkOHekREIoyCX0Qkwij4RUQijIJfRCTCKPhFRCLMaYPfzJqY2VIzW2Vm68zsp+WMaWxmr5nZVjNbYmZx1VGsiIhUXUX2+POBC9x9KDAMmGhmY8uMuQ047O69gd8DT4S2TBERCZXTBr8H5AQfRgdvZa/XOAmYHbz/JvB1M7OQVSkiUg+4O099vIX1u7PDWkeFPsBlZg2BZUBv4Bl3X1JmSDdgJ4C7F5lZFtAeOFBmOzOAGQCxsbFVq1xEpA7JLyrmobfW8PaKXRwrKGZg11Zhq6VCf9x192J3HwZ0B0ab2eAyQ8rbu//SVdzdfaa7x7t7fExMlT5xLCJSZ2QdL+SWF5fy9opdPHBxX34wsV9Y66lUywZ3P2Jm/wQmAmtLPZUB9AAyzCwKaA0cClWRIiJ11Y6Dx5mWtJSMQ7k8OWUYk4Z1C3dJFTqrJ8bM2gTvNwUuBDaWGbYAuDV4fzLwD3f/0h6/iEgkWbHjMNc8m8zBnAJevn1MrQh9qNgefxdgdvA4fwPgdXd/x8weA1LdfQHwIvCSmW0lsKc/pdoqFhGpAz5Ym8l35q2kU6smJCaM4uyYFuEu6d9OG/zuvhoYXs7yR0rdzwOuC21pIiJ1j7vz4udp/OK9DQzr0YYXbomnfYvG4S7rv4StLbOISH1TVFzCY++sZ86i7Vx2Tmd+d/0wmkQ3DHdZX6LgFxEJgWP5RXx77go+3riPO889ix9M7E+DBrXz40wKfhGRKtqbncf0pBQ2ZGbzs6sHc/PYnuEu6ZQU/CIiVbBxTzbTE1M4klvIi7eO4vz+HcNd0mkp+EVEztBnW/Zzz8vLada4Ia/fOY7B3VqHu6QKUfCLiJyB11N28qO319C7YwsSE0bRpXXTcJdUYQp+EZFKcHd++7fNPP3JVs7tG8MzNw6nZZPocJdVKQp+EZEKyi8q5sE3VrNg1W6mju7BY5MGE92w7l3PSsEvIlIBh48VcOdLy1iafogfTOzPXV87i7rafV7BLyJyGtsPHiMhMYWMI7k8NXU4Vw7tGu6SqkTBLyJyCsu2H+aOOam4O6/ePob4uHbhLqnKFPwiIifx3ppM7n9tJV1bNyExYTS9OjQPd0khoeAXESnD3Zn56Tb+7/2NjOzZlj/dEk+75o3CXVbIKPhFREopKi7h0QXreGXJDi4f0oXfXje0VjZaqwoFv4hIUE5+Ed96dTmfbNrPXV87m+9f0q/WNlqrCgW/iAiwJyvQaG3T3qP83zfOYero2HCXVG0U/CIS8TZkZpOQmMLRvEJmTRvF1/rGhLukaqXgF5GI9q/N+7n3leW0aBzFG3eNZ2DXVuEuqdop+EUkYr26ZAcP/2Ut/Tq1ZNa0UXRu3STcJdUIBb+IRJySEufXf9vEH//5Bef1i+HpG0fQonHkxGHkfKUiIkBeYTEPvLGKd1ZnctOYWH561SCi6mCjtapQ8ItIxDh0rIAZc1JJ3X6YH17anxnn1t1Ga1Wh4BeRiJB24BgJiUvZnZXHMzeO4PIhXcJdUtgo+EWk3ktNP8Qdc1IxM+beMYaRPet+o7WqOO2BLTPrYWafmNkGM1tnZt8pZ8x5ZpZlZiuDt0eqp1wRkcr566rd3PjCEto0a8Tb94yP+NCHiu3xFwHfc/flZtYSWGZmH7n7+jLjPnP3K0JfoohI5bk7z/1rG098sJFRcW2ZeXM8betRo7WqOG3wu3smkBm8f9TMNgDdgLLBLyJSKxQWl/DIX9Yyd+lOrhralV9NHlLvGq1VRaWO8ZtZHDAcWFLO0+PMbBWwG3jA3deVs/4MYAZAbGz97YMhIuFzNK+Qe19dwaeb93Pf+b35n4v61stGa1VR4eA3sxbAW8D97p5d5unlQE93zzGzy4A/A33KbsPdZwIzAeLj4/2MqxYRKUdmVi4JiSls2ZfDE9eeww2jtINZngp9asHMogmE/ivuPr/s8+6e7e45wfvvAdFm1iGklYqInMK63Vlc/UwyGYdzSZw2SqF/ChU5q8eAF4EN7v67k4zpHByHmY0ObvdgKAsVETmZTzbt4/rnFtHQjDfvHse59by7ZlVV5FDPBOBmYI2ZrQwu+xEQC+DuzwGTgbvNrAjIBaa4uw7liEi1e3nxdh5dsI7+nQON1jq1ioxGa1VRkbN6PgdO+ZcRd38aeDpURYmInE5JifPEBxt5/tNtXNC/I09NHU7zCGq0VhX6LolInZNXWMz/vL6S99bs4eaxPXn0yoER12itKhT8IlKnHMzJ5445qazYeYQfXz6A277SKyIbrVWFgl9E6owv9ueQkJjC3uw8/njTCCYOjtxGa1Wh4BeROmFpWqDRWlQDY+6MsYyIbRvukuosBb+I1Hp/WbmLB99YTfd2TUmaNprY9s3CXVKdpuAXkVrL3Xn2n1/w6w83MaZXO56/eSRtmqnRWlUp+EWkViosLuHHb6/ltdSdXD2sK09MHkLjKDVaCwUFv4jUOtl5hdz7ynI+23KAb1/Qm+9e1Fdn7oSQgl9EapVdR3KZnpjCF/tz+NXkIVwf3yPcJdU7Cn4RqTXW7spielIKuQXFzJ4+mgm91euxOij4RaRW+HjDXr41dwVtmzXi5XvG0LdTy3CXVG8p+EUk7F5alM6jC9YxqGtrXrw1no5qtFatFPwiEjYlJc4v39vAC5+nceGAjvxh6nCaNVIsVTd9h0UkLHILivnuayv5YN0epo2P4+ErBtJQl0isEQp+EalxB3LyuW12KqszjvDIFQOZ/pVe4S4poij4RaRGbd2XQ0LSUvYfzee5b47kkkGdw11SxFHwi0iNWbztIDPmpNIoqgHzZoxjWI824S4pIin4RaRGvL0ig++/uZqe7ZuTOG0UPdqp0Vq4KPhFpFq5O0/9Yyu/+2gzY89qx/PfjKd1s+hwlxXRFPwiUm0Kikr40dtreHNZBt8Y3o3Hrx1CoyhdIjHcFPwiUi2ycgu5++VlLPziIPdf2IfvfL2PGq3VEgp+EQm5jMPHSUhMIf3gMX573VCuHdk93CVJKQp+EQmp1RlHmJ6USn5RoNHa+LPVaK22Oe3BNjPrYWafmNkGM1tnZt8pZ4yZ2R/MbKuZrTazEdVTrojUZh+t38sNzy+mcVQD5t89XqFfS1Vkj78I+J67LzezlsAyM/vI3deXGnMp0Cd4GwP8MfiviESIxOQ0HntnPUO6teZPt8bTsaUardVWpw1+d88EMoP3j5rZBqAbUDr4JwFz3N2BxWbWxsy6BNcVkXqsuMT5+bvrSUxO5+KBnXhyynCaNtIlEmuzSh3jN7M4YDiwpMxT3YCdpR5nBJcp+EXqseMFRXxn3ko+Wr+X6RN68b+XD1CjtTqgwsFvZi2At4D73T277NPlrOLlbGMGMAMgNja2EmWKSG2z/2g+t89OYc2uLH5y5UCmTVCjtbqiQsFvZtEEQv8Vd59fzpAMoPSFMbsDu8sOcveZwEyA+Pj4L70xiEjdsGXvURKSUjiYU8DzN8dz0cBO4S5JKqEiZ/UY8CKwwd1/d5JhC4Bbgmf3jAWydHxfpH5auPUA3/jjQvKLSnj9znEK/TqoInv8E4CbgTVmtjK47EdALIC7Pwe8B1wGbAWOAwmhL1VEwu2tZRk8NH81vTo0Z9a0UXRvq0ZrdVFFzur5nPKP4Zce48C9oSpKRGoXd+f//X0LT368hQm92/PsTSNp3VSN1uoqfXJXRE6poKiEh95azfwVu5g8sju/vOYcNVqr4xT8InJSWccLufPlVBZvO8T3LurLfRf0VqO1ekDBLyLl2nnoONMSl7Lj0HF+f8NQrhmuRmv1hYJfRL5k5c4j3D47hcJi56XbxjD2rPbhLklCSMEvIv/lg7V7uP+1FcS0bMy8aaPp3bFFuEuSEFPwiwgQOHNnVnI6P393PUO7t+GFW+Pp0KJxuMuSaqDgFxGKS5yfvbOepIXpTBzUmd/fMEyN1uoxBb9IhDteUMS3567g7xv2ccdXe/HDSwfQQI3W6jUFv0gE25edx22zU1m3O4ufTRrEzePiwl2S1AAFv0iE2rz3KAmJKRw+XsCfbonn6wPUcydSKPhFItDnWw5w98vLaNqoIa/fOY7B3VqHuySpQQp+kQjzeupOfjR/DWfHtGBWwii6tWka7pKkhin4RSKEu/O7jzbz1D+28tU+HXjmphG0aqJGa5FIwS8SAfKLivnBm6v588rd3BDfg59fM5johmq0FqkU/CL13JHjBcx4aRlL0w7x4CX9uOe8s9VoLcIp+EXqsR0HjzMtaSkZh3J5csowJg3rFu6SpBZQ8IvUU8t3HOaO2akUu/Py7WMY3atduEuSWkLBL1IPvb8mk/tfW0nn1k1InDaKs2LUaE3+Q8EvUo+4Oy98lsYv39/A8B5t+NMt8bRXozUpQ8EvUk8UFZfwk7+u4+XFO7j8nC789vqhNIlWozX5MgW/SD1wLL+I+15dzieb9nPn187iB5f0V6M1OSkFv0gdtzc7j+lJKWzIzObnVw/mm2N7hrskqeUU/CJ12MY92SQkppCdW8iL00Zxfr+O4S5J6gAFv0gd9enm/dzzynKaN27I63eNY1BXNVqTijntZ7bNbJaZ7TOztSd5/jwzyzKzlcHbI6EvU0RKm7d0BwlJKXRv25Q/3ztBoS+VUpE9/iTgaWDOKcZ85u5XhKQiETmpkhLnN3/bxLP//IJz+8bwzI3DaalGa1JJpw1+d//UzOKqvxQROZW8wmIefHM1f121m6mjY3ls0iA1WpMzEqpj/OPMbBWwG3jA3deFaLsiAhw+VsCMl1JJST/MQ5f2585zz1KjNTljoQj+5UBPd88xs8uAPwN9yhtoZjOAGQCxsbEheGmR+i/9wDESklLYdSSXp6YO58qhXcNdktRxVf490d2z3T0neP89INrMOpxk7Ex3j3f3+JiYmKq+tEi9t2z7Ia55Npkjxwt49fYxCn0JiSoHv5l1tuDvnGY2OrjNg1Xdrkike3d1JlP/tITWTaOZf88E4uPUXVNC47SHesxsLnAe0MHMMoBHgWgAd38OmAzcbWZFQC4wxd292ioWqefcnec/3cbj728kvmdbZt4ST7vmjcJdltQjFTmrZ+ppnn+awOmeIlJFRcUlPLJgHa8u2cEVQ7rwm+vUaE1CT5/cFaklcvKLuPeV5fxr837uPu9sHry4nxqtSbVQ8IvUAplZuUxPSmXz3qP83zfOYeponfUm1UfBLxJm63dnMz0phZz8ImZNG8XX+uqMN6leCn6RMPpk0z7ue2U5rZpG88Zd4xjQpVW4S5IIoOAXCZNXl+zg4b+spV+nlsyaNorOrZuEuySJEAp+kRpWUuI88eFGnv/XNs7rF8PTN46gRWP9KErN0WwTqUF5hcV87/VVvLsmk5vGxPLTqwYRpUZrUsMU/CI15NCxAu6Yk8qy7Yf50WX9ueOrarQm4aHgF6kBaQeOkZC4lMysPJ69aQSXndMl3CVJBFPwi1SzlPRD3DEnlQZmvHrHWEb2bBvukiTCKfhFqtGCVbt54PVVdG/blMSEUfRs3zzcJYko+EWqg7vz7D+/4NcfbmJ0XDuev3kkbdVoTWoJBb9IiBUWl/Dwn9cyL2Unk4Z15VeTh9A4So3WpPZQ8IuE0NG8Qu55ZTmfbTnAty7ozf9c1Fdn7kito+AXCZHdR3KZnpTC1n05/OraIVw/qke4SxIpl4JfJATW7spielIKuQXFJCaM4qt91GhNai8Fv0gVfbJxH/e+upw2TaN54+5x9O+sRmtSuyn4RargpUXpPLpgHQO7tuLFW0fRqZUarUntp+AXOQMlJc7jH2xk5qfbuKB/R56aOpzmarQmdYRmqkgl5RUW893XVvL+2j3cMq4nj1wxUI3WpE5R8ItUwoGcfO6Yk8rKnUf48eUDuO0rvXS6ptQ5Cn6RCvpifw4JiSnszc7jjzeNYOJgNVqTuknBL1IBS7YdZMZLy4hqYMybMZbhsWq0JnWXgl/kNP6ychcPvrGa7u2akjRtNLHtm4W7JJEqOe1fpMxslpntM7O1J3nezOwPZrbVzFab2YjQlylS89ydpz7ewnfmrWR4bBvm3z1eoS/1QkVORUgCJp7i+UuBPsHbDOCPVS9LJLwKi0v4/pur+e1Hm7lmeDfm3DaaNs3UXVPqh9Me6nH3T80s7hRDJgFz3N2BxWbWxsy6uHtmiGoUqVHZeYXc8/JyPt96gG9/vQ/fvbCPztyReiUUx/i7ATtLPc4ILlPwS51SXOJ8tH4Pv/nbZtIPHOPXk4dwXbwarUn9E4rgL29XyMsdaDaDwOEgYmNjQ/DSIlWXdbyQ11J3MHvhdnYdyaVbm6bMnj6aCb07hLs0kWoRiuDPAErvFnUHdpc30N1nAjMB4uPjy31zEKkpW/cdJTE5nfnLd5FbWMzoXu14+IoBXDigkz6JK/VaKIJ/AXCfmc0DxgBZOr4vtVVJifOvzfuZlZzGZ1sO0CiqAZOGdmXahDgGdW0d7vJEasRpg9/M5gLnAR3MLAN4FIgGcPfngPeAy4CtwHEgobqKFTlTOflFvLUsg9kL09l24BgdWzbmexf15cYxsbRv0Tjc5YnUqIqc1TP1NM87cG/IKhIJoR0Hj5O0MJ03UndyNL+IoT3a8OSUYVw6uAuNonQ4RyKTPrkr9Y67s+iLg8xKTufjjXtpaMZl53QhYUKcWi2IoOCXeiSvsJi3V+wiKTmdTXuP0q55I+49rzffHNuTzq11gRSRExT8UudlZuUyZ9F25i7dwZHjhQzo0opfTR7CVUO70iS6YbjLE6l1FPxSJ7k7y3ccZlZyOh+s3YO7c9HATiRM6MWYXu30SVuRU1DwS52SX1TMu6szSUxOZ82uLFo2iWL6hDhuGRdHj3ZqoCZSEQp+qRP2H83nlSXbeXnxDg7k5HN2THN+dvVgvjG8m651K1JJ+omRWm3trixmJafxzqpMCopLOK9fDAkTevHV3h1o0ECHc0TOhIJfap2i4hI+XLeXpIVppKQfplmjhkwZ3YNbx8dxdkyLcJcnUucp+KXWOHK8gLlLd/LSonR2Z+XRo11Tfnz5AK4f1YNWTaLDXZ5IvaHgl7DbvDfQLO3tFRnkFZYw7qz2/OSqQXx9QCca6nCOSMgp+CUsSkqcf2zcR+LCNJK3HqRxVAOuGd6NW8fHMaBLq3CXJ1KvKfilRh3NK+SN1AxmL0pn+8HjdG7VhAcv6cfU0bG0a65LG4rUBAW/1Ii0A8eYvTCdN5dlkJNfxMiebXng4n5MHNyZaPW+F6lRCn6pNu7O51sPkJiczieb9hHVwLhiSFemjY9jaI824S5PJGIp+CXkcguKmb8ig6TkdLbsy6FDi0Z864I+fHNMLB1bqVmaSLgp+CVkdh3JZc6idOYt3UlWbiGDurbiN9cN5cqhXWgcpWZpIrWFgl+qxN1JST9MYnIaH67bA8DEwZ1JmNCL+J5t1SxNpBZS8MsZyS8q5q+rMklMTmPd7mxaN43mjnPP4pZxcXRr0zTc5YnIKSj4pVL2Zefx8uLtvLp0BwdyCujTsQW/uGYw1wzvRrNGmk4idYF+UqVCVu08QmJyGu+uyaSoxLmgX0cSJvRiQu/2OpwjUsco+OWkCotL+GDtHhKT01i+4wgtGkdx05ieTBsfR1yH5uEuT0TOkIJfvuTQsQLmLt3BS4u2syc7j57tm/HolQOZPLI7LdUsTaTOU/DLv23ck03i5+n8eeUu8otK+ErvDvzimsGc36+jet+L1CMK/ghXXOJ8vGEvicnpLNp2kCbRDbh2ZHemjY+jb6eW4S5PRKpBhYLfzCYCTwINgRfc/fEyz08Dfg3sCi562t1fCGGdEmLZeYW8nrKT2YvS2Xkol66tm/DQpf2ZMqoHbZqpWZpIfXba4DezhsAzwEVABpBiZgvcfX2Zoa+5+33VUKOE0Bf7c/7dLO14QTGj4tryw0sHcPHATkSpWZpIRKjIHv9oYKu7bwMws3nAJKBs8EstVVLifLplP0kL0/nnpv00atiAK4d2JWFCHIO7tQ53eSJSwyoS/N2AnaUeZwBjyhl3rZmdC2wGvuvuO8sZIzXoWH4R85dnkLQwnS/2HyOmZWO+e2FfbhwTS0zLxuEuT0TCpCLBX97pHF7m8V+Bue6eb2Z3AbOBC760IbMZwAyA2NjYSpYqFbXz0PFAs7SUnRzNK2JI99b8/oahXH5OVxpF6XCOSKSrSPBnAD1KPe4O7C49wN0Plnr4J+CJ8jbk7jOBmQDx8fFl3zykCtydxdsOkbQwjY/W78XMuHRwZxImxDEiVs3SROQ/KhL8KUAfM+tF4KydKcCNpQeYWRd3zww+vArYENIq5aTyCotZsHI3iQvT2ZCZTdtm0dz1tbO5eVxPurRWszQR+bLTBr+7F5nZfcCHBE7nnOXu68zsMSDV3RcA3zazq4Ai4BAwrRprFmBvdh4vLQo0Szt0rIB+nVry+DfO4erh3WgSrd73InJy5h6eIy7x8fGempoalteuy5bvOExScjrvrcmk2J0LB3QiYUIc485SszSRSGBmy9w9virb0Cd364CCohLeX5vJrOR0Vu08QsvGUdw6Po5bx8UR275ZuMsTkTpGwV+LHcjJZ+6SHby0eDv7juZzVofmPDZpENeO6E7zxvqvE5Ezo/SohdbtziIxOZ0Fq3ZTUFTCuX1jeGJyHF/rE6NmaSJSZQr+WqK4xPlo/R5mJaezNO0QTaMbcn18oFla745qliYioaPgD7Os44W8lrqD2Qu3s+tILt3bNuV/LxvA9fE9aN1Mve9FJPQU/GGydd9REpPTmb98F7mFxYzp1Y6HrxjIRQM70VCHc0SkGin4a1BJifOvzfuZlZzGZ1sO0CiqAZOGdmXahDgGdVWzNBGpGQr+GpCTX8RbyzKYvTCdbQeO0alVYx64uC9TR8fSvoWapYlIzVLwV6MdB4+TtDCdN1J3cjS/iGE92vDklGFcOriLmqWJSNgo+EPM3Vn0xUFmJafz8ca9NDTj8iFdmDY+juGxbcNdnoiIgj9U8gqLeXvFLpKS09m09yjtmjfivvN7882xPenUqkm4yxMR+TcFfxVlZuUyZ9F25i7dwZHjhQzo0opfTR7CVUO7qlmaiNRKCv4z4O4s33GYWcnpfLB2D+7OxQMDve9H92qnZmkiUqsp+Cshv6iYd1dnkrQwndUZWbRqEsVtX+nFzWN70qOdmqWJSN2g4K+A/UfzeWXJdl5evIMDOfmcHdOcn109mGtHdKNZI30LRaRuUWqdwtpdWcxKTuOdVZkUFJdwfr8YEib04iu9O6hZmojUWQr+MoqKS/hw3V6SFqaRkn6Y5o0aMnV0D24dH8dZMS3CXZ6ISJUp+IOOHC9g7tKdvLQond1ZefRo15QfXz6A60f1oFUTNUsTkfoj4oN/895As7S3V2SQV1jC+LPb89NJg7mgf0c1SxOReikig7+kxPnHxn0kLkwjeetBGkc14Jrh3Zg2IY7+nVuFuzwRkWoVUcF/NK+QN1IzmL0one0Hj9OldRO+P7EfU0fF0rZ5o3CXJyJSIyIi+NMOHGP2wnTeXJZBTn4RI3u25cFL+nHJoM5EN1SzNBGJLPU2+N2dz7ceIDE5nU827SOqgXHlkEDv+yHd24S7PBGRsKl3wZ9bUMz8FRkkJaezZV8OHVo04tsX9OGmsbF0bKlmaSIiFQp+M5sIPAk0BF5w98fLPN8YmAOMBA4CN7h7emhLPbVdR3KZsyideUt3kpVbyOBurfjtdUO5YmgXGkepWZqIyAmnDX4zawg8A1wEZAApZrbA3deXGnYbcNjde5vZFOAJ4IbqKLg0dycl/TCJyWl8uG4PZsYlgzqRMKEX8T3bqlmaiEg5KrLHPxrY6u7bAMxsHjAJKB38k4CfBO+/CTxtZubuHsJa/y2/qJi/rsokMTmNdbuzad00mhnnns3N43rSrU3T6nhJEZF6oyLB3w3YWepxBjDmZGPcvcjMsoD2wIFQFFnaPzbu5ftvruZATgF9O7Xgl9ecwzXDu9G0kQ7niIhUREWCv7zjJWX35CsyBjObAcwAiI2NrcBLf1nP9s0Z2r0NCRN6MaF3ex3OERGppIoEfwbQo9Tj7sDuk4zJMLMooDVwqOyG3H0mMBMgPj7+jA4DnR3TghenjTqTVUVEBKjIp5dSgD5m1svMGgFTgAVlxiwAbg3enwz8o7qO74uISNWcdo8/eMz+PuBDAqdzznL3dWb2GJDq7guAF4GXzGwrgT39KdVZtIiInLkKncfv7u8B75VZ9kip+3nAdaEtTUREqoMa1YiIRBgFv4hIhFHwi4hEGAW/iEiEUfCLiEQYC9fp9ma2H9h+hqt3oBraQYiUojkm1akq86unu8dU5cXDFvxVYWap7h4f7jqk/tIck+oU7vmlQz0iIhFGwS8iEmHqavDPDHcBUu9pjkl1Cuv8qpPH+EVE5MzV1T1+ERE5Q9Ue/GbWxMyWmtkqM1tnZj8t9dxUM/tfM2trZm+b2erg2MFltvG8mU0ws1+b2cbguLfNrE2pMT80s61mtsnMLgku62Fmn5jZhuBrf6fU+HZm9pGZbQn+27a6vxcSGhWcU/3NbJGZ5ZvZA2XWn2Vm+8xsbTnbHmdmfzKzi8xsmZmtCf57QakxI4PLt5rZHyx4NaDKzk+pnaoyv061bpn1bwrOk9VmttDMhpYaMzE4T7aa2UOllr8SXL42OIejg8stOA+kIsgFAAAFJElEQVS3Brc34rRfpLtX643A1blaBO9HA0uAscHHs4GRwK+BR4PL+gMfl9nGSgItoS8GooLLngCeCN4fCKwCGgO9gC+C47sAI4JjWgKbgYHBx78CHgref+jEtnSr/bcKzqmOwCjgF8ADZdY/FxgBrC1n2z8FrgWGA12DywYDu0qNWQqMC9bxPnBpcHml5me4v4+6hX5+nWrdMuuPB9oGl10KLAnebxicH2cBjYLz5kRmXRbcvgFzgbtLLX8/uHzsiW2d6lbte/wekBN8GB28eXAvaRiwnMAPxsfB8RuBODPrBGBmA4DN7l7s7n9z96LgthYTuBoYBC72Ps/d8909DdgKjHb3THdfHtzuUWADgesDn1hndvD+bODqavjypRpUZE65+z53TwEKy1n/U8q5QlzQ14G/u/sKdz9xpbl1QBMza2xmXYBW7r7IAz91cwjOncrOzzP/Dkh1qsr8Otm6ENgzL7X+Qnc/HBxXeq6MBra6+zZ3LwDmEZg/uPt7we07gZ2P0vNrTvCpxUCb4Dw9qRo5xm9mDc1sJbAP+MjdlxDYo1oV/CJWAd8Ijh0N9OQ/X9SlwAflbHY6gXc5KP+C8N1KDzazuOBrLgku6uTumQDBfzue+VcoNa0Cc+pMttkBKHT3rDJPXQuscPd8AvMqo9RzX5prQZWan1K7VGV+nWRdTrH+bVQuy6KBm/lPLlZ6ftVI8Af31ocRCPPRwWP4E/nPF/s40Db4zfoWsAI4sed0CWWC38z+N/j8KycWlfeypca3AN4C7nf37JB8URJWFZhTZ+Ji4G+lF5jZIAKHbe48sai8csqsU6n5KbVPVebXSdalvPXN7HwCwf+DE4vK22SZx88Cn7r7Z5VY579U6ApcoeLuR8zsnwS+ARcT2JMiGMYJ8O9fh9KANDNrBrQp9Ss3ZnYrcAXw9VLvnCe9IHzw3fEt4BV3n19qzF4z6+LumcFfi/aF+uuV6neyOXWGLgV+d+KBmXUH3gZucfcvgosz+M9vo1BqrgXXqdT8lNqtKvOrzLpry65vZkOAFwj8jehgcPEp54qZPQrE8J8dkdOuU56aOKsn5sTZDWbWFLgQ2ELgj2AHg8vbWOBC7gC3E3g3ywbOBz4pta2JBN4Zr3L346VeZgEwJXgMthfQB1gafBN5Edjg7r/jv5W+QPytwF9C9kVLtarInDqDbRowhMCJBAS3/y7wQ3dPPjEueFjwqJmNDa5zC8G5U9n5eSZ1SvWryvw6ybobzaw1/515scB84GZ331xqEylAHzPrFczEKQTmD2Z2O4EjIFPdvaTUOguAW4Jn94wFsk4cxj6Zmtjj7wLMNrOGBN5oXifwB4+/lxozAJhjZsXAegK/+kBgD+zNUuOeJnBmxEeBnzkWu/tdHrj4++vBdYuAe9292My+QuBY2JrgYSSAH3ngGsKPA6+b2W3ADnTN4LrktHPKzDoDqUAroMTM7idwdkS2mc0FzgM6mFkG8CiBvzOtKLWXfh/QG3jYzB4OLrvY3fcBdwNJQFMCv7qf+PW9UvMzxN8TCZ0znl/lrevu75jZZP478x4B2gPPBudKkbvHu3uRmd0HfEjgDJ9Z7r4uuM5zBDoaLwquM9/dHyNwPfTLCJw0cJzg0ZNTCcsnd83sBeCF4F+gTzVuOTDG3b90ZoZIaRWdU6dY/8cEzqaYF9rKpD4Iwfyq0vqhppYNIiIRRi0bREQijIJfRCTCKPhFRCKMgl9EJMIo+EVEIoyCX0Qkwij4RUQizP8HI6IZQCjlq18AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "get_case_plot(df[df['case_no_int'].isin(contact_map[43])])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Hi Enzo,

Adding a phcovid_plot module that contains a function that plots the cumulative case graph for the dataframe from get_cases() or a subset (i.e. among contacts of PH9 or those in Taguig). Please let me know if you would need me to change some parts of formatting. 

Going forward, we can include other necessary plot functions in the module. 

Thanks! 