### PR TITLE
feat(phcovid): integrate ds-ph gsheet data with this library's dataset

### DIFF
--- a/phcovid/constants.py
+++ b/phcovid/constants.py
@@ -28,9 +28,3 @@ NONE_ALIAS = [
     "none",
     "",
 ]
-
-DSPH_GSHEET_TARGETS = [
-    "case no.",  # for row searching
-    "status",
-    "symptoms",
-]

--- a/phcovid/constants.py
+++ b/phcovid/constants.py
@@ -28,3 +28,9 @@ NONE_ALIAS = [
     "none",
     "",
 ]
+
+DSPH_GSHEET_TARGETS = [
+    "case no.",  # for row searching
+    "status",
+    "symptoms",
+]

--- a/phcovid/data_extractor/arcgis.py
+++ b/phcovid/data_extractor/arcgis.py
@@ -16,4 +16,5 @@ URL = (
 def extract_arcgis_data():
     import json
     from urllib.request import urlopen
+
     return json.loads(urlopen(URL).read())

--- a/phcovid/phcovid.py
+++ b/phcovid/phcovid.py
@@ -7,6 +7,7 @@ from .constants import NONE_ALIAS
 from .constants import VAL_ALIAS
 from .constants import RENAME_DICT
 from .constants import DATE_COLS
+from .constants import DSPH_GSHEET_TARGETS
 from .data_extractor import extract_arcgis_data
 from .data_extractor import extract_dsph_gsheet_data
 
@@ -68,13 +69,7 @@ def parse_numeric(s):
     return case_list
 
 
-def attach_supplement_data(dataframe):
-    # change targets to extend the dataset
-    targets = [
-        "case no.",  # for row searching
-        "status",
-        "symptoms",
-    ]
+def attach_supplement_data(dataframe, targets=DSPH_GSHEET_TARGETS):
     missing = extract_dsph_gsheet_data(target_columns=targets)
 
     for target in targets[1:]:

--- a/test_phcovid.py
+++ b/test_phcovid.py
@@ -16,9 +16,11 @@ def test_get_case_network():
 
 def test_arcgis_extract():
     from phcovid.data_extractor import extract_arcgis_data
+
     assert extract_arcgis_data() != {}
 
 
 def test_dsph_gsheet_extraction():
     from phcovid.data_extractor import extract_dsph_gsheet_data
+
     assert extract_dsph_gsheet_data() != []


### PR DESCRIPTION
Integrated supplementary data to complete the lirbary's data. These columns are `status` and `symptoms` which we will be taking from `dsph_gsheet.py` output.

## Changes

- [x] Modified HTML view extraction and data cleaning; realized that even though list comprehension is faster than for-loops, it's more restrictive; [thus changed data extraction logic](https://github.com/mamerisawesome/phcovid/blob/2aaff8a78ab1d9f89aaf08567f100c642870067e/phcovid/data_extractor/dsph_gsheet.py#L44-L54)
- [x] Integrated data from the output of `dsph_gsheet.py` and integrated that with `phcovid`'s cases data; [also enabled a way to update the targets](https://github.com/mamerisawesome/phcovid/blob/2aaff8a78ab1d9f89aaf08567f100c642870067e/phcovid/phcovid.py#L72-L77) (or data we want from the sheet) through an array

## Note

* One of the concerns that we may have from the Google Sheet dataset is that the team behind it is different from those handling the ARCGIS dataset. Hence, for `status` and `symptoms`, it may not be completely synced at all times with the other columns.