### PR TITLE
Changes for faster runtime for get_cases - 55% speedup

### DIFF
--- a/phcovid/constants.py
+++ b/phcovid/constants.py
@@ -15,6 +15,15 @@ RENAME_DICT = {
     "attributes.petsa": "date",
 }
 
+
+# Mapping between gsheet column names to be added and their corresponding name in the final dataframe
+GSHEET_TARGET_COLUMNS = {
+    "status": "status",
+    "symptoms": "symptoms",
+    "date of announcement to the public": "announcement_date",
+}
+
+
 DATE_COLS = ["confirmation_date", "date", "announcement_date"]
 
 VAL_ALIAS = [

--- a/phcovid/data_extractor/dsph_gsheet.py
+++ b/phcovid/data_extractor/dsph_gsheet.py
@@ -1,4 +1,5 @@
 import re
+import pandas as pd
 
 URL = (
     "https://docs.google.com"
@@ -7,12 +8,7 @@ URL = (
     "/htmlview"
 )
 
-TARGET_COLUMNS = (
-    "case no.",
-    "status",
-    "symptoms",
-    "date of announcement to the public",
-)
+GSHEET_ID = {"case no.": "case_no"}
 
 
 def _extract_by_targets(headers, data, targets):
@@ -60,7 +56,10 @@ def _clean_html(soup_data=None, headers=None, valid_idx=[]):
     return output
 
 
-def extract_dsph_gsheet_data(target_columns=TARGET_COLUMNS):
+def extract_dsph_gsheet_data(target_columns):
+    """
+    Returns google sheets worksheet in pd.DataFrame format
+    """
     from urllib.request import urlopen
     from bs4 import BeautifulSoup
 
@@ -73,6 +72,9 @@ def extract_dsph_gsheet_data(target_columns=TARGET_COLUMNS):
     # select table rows
     rows = soup.select("tbody > tr")
     headers = _clean_html(headers=rows[0])
-    data = _extract_by_targets(headers, rows[1:], targets=target_columns)
+    id_targets = list(GSHEET_ID.keys()) + list(target_columns.keys())
+    data = _extract_by_targets(headers, rows[1:], targets=id_targets)
+    id_targets_standard = list(GSHEET_ID.values()) + list(target_columns.values())
+    df = pd.DataFrame(data, columns=id_targets_standard)
 
-    return data
+    return df

--- a/test_phcovid.py
+++ b/test_phcovid.py
@@ -1,6 +1,7 @@
 from pandas import DataFrame
 from phcovid import get_case_network
 from phcovid import get_cases
+from phcovid.constants import GSHEET_TARGET_COLUMNS
 
 
 def test_get_cases():
@@ -23,4 +24,6 @@ def test_arcgis_extract():
 def test_dsph_gsheet_extraction():
     from phcovid.data_extractor import extract_dsph_gsheet_data
 
-    assert extract_dsph_gsheet_data() != []
+    assert isinstance(
+        extract_dsph_gsheet_data(target_columns=GSHEET_TARGET_COLUMNS), DataFrame
+    )


### PR DESCRIPTION
To speedup the process of merging the raw json data with the gsheets data source, I increase the usage of pandas when performing operations that can be *vectorized*.

The following changes were made to speed up `get_cases`:
1. `extract_dsph_gsheet_data` now returns a pandas dataframe straight.
2. Standardized `targets` input, defined in `constants.py`. This means we can add new ghseets columns by editing only `GSHEET_TARGET_COLUMNS`
3. `supplement_data` now performs the gsheets data replacements in a vectorized way with the `loc` method. Intersections in `case_id` are also now detected with *sets* instead of *lists* (more efficient),
4. `get_cases` is now supplements the data before applying the aliasing. This makes sense so the supplemented data can still be aliased.
5. All the elements in `NONE_ALIAS` will now be converted to a `numpy.nan` instead of just a "none" string. This allows us to utiilize the `NaN` methods in pandas.
6. Tests were updated to reflect 1

Note: 1 test fails related to `phcovid_network.py`. I am still working on figuring out how this happened. Hope to work with @andrewnyu to figure this out.