### PR TITLE
feat(cases): type casted age, case_no, and age

### DIFF
--- a/phcovid/phcovid.py
+++ b/phcovid/phcovid.py
@@ -61,7 +61,7 @@ def supplement_data(dataframe, targets):
 
     for df_ in [dataframe, missing]:
         df_["case_no_num"] = (
-            df_["case_no"].apply(lambda x: x.split("H")[-1]).astype(np.int64)
+            df_["case_no"].apply(lambda x: x.split("H")[-1]).astype(np.uint64)
         )
 
     # Make sure both dataframe and missing are sorted based on `case_no`
@@ -129,7 +129,7 @@ def get_cases(
         lambda x: parse_numeric(x)
     )
 
-    df_aliased["age"] = df_aliased["age"].astype(np.int8)
+    df_aliased["age"] = df_aliased["age"].astype(np.uint8)
     df_aliased["sex"] = df_aliased["sex"].astype("category")
 
     for col in DATE_COLS:

--- a/phcovid/phcovid.py
+++ b/phcovid/phcovid.py
@@ -61,7 +61,7 @@ def supplement_data(dataframe, targets):
 
     for df_ in [dataframe, missing]:
         df_["case_no_num"] = (
-            df_["case_no"].apply(lambda x: x.split("H")[-1]).astype(int)
+            df_["case_no"].apply(lambda x: x.split("H")[-1]).astype(np.int64)
         )
 
     # Make sure both dataframe and missing are sorted based on `case_no`
@@ -128,6 +128,9 @@ def get_cases(
     df_aliased["contacts_num"] = df_aliased["contacts"].apply(
         lambda x: parse_numeric(x)
     )
+
+    df_aliased["age"] = df_aliased["age"].astype(np.int8)
+    df_aliased["sex"] = df_aliased["sex"].astype("category")
 
     for col in DATE_COLS:
         df_aliased[col] = df_aliased[col].apply(lambda x: fix_dates(x))


### PR DESCRIPTION
Converted `age`, `case_no`, and `sex` data types into their proper types.

### Summary

`age` column is casted to `numpy.int8` data type from `object`. This is within the range of -128 to +127 given the known trend of human lifespan of around 100 years.

`case_no` column is casted to `numpy.int64` from `float64` due to how case number will exist within integer values.

`sex` column is casted to `category` from `object`. Currently, we will have values `M` and `F` for sex. As this is not gender, suggesting that we can be okay with having two elements for `sex`.

### Other notes

With the existence of enums or categories within Pandas as a type, we may also consider `status` as a candidate for categories. But regressed for now as it may complicate extraction from the dataset.

Closes Issue #26 