### PR TITLE
feat(cases): soft fail on dsph ghseet extraction

### DIFF
--- a/phcovid/phcovid.py
+++ b/phcovid/phcovid.py
@@ -61,7 +61,7 @@ def supplement_data(dataframe, targets):
 
     for df_ in [dataframe, missing]:
         df_["case_no_num"] = (
-            df_["case_no"].apply(lambda x: x.split("H")[-1]).astype(np.int64)
+            df_["case_no"].apply(lambda x: x.split("H")[-1]).astype(np.uint64)
         )
 
     # Make sure both dataframe and missing are sorted based on `case_no`
@@ -129,7 +129,7 @@ def get_cases(
         lambda x: parse_numeric(x)
     )
 
-    df_aliased["age"] = df_aliased["age"].astype(np.int8)
+    df_aliased["age"] = df_aliased["age"].astype(np.uint8)
     df_aliased["sex"] = df_aliased["sex"].astype("category")
 
     for col in DATE_COLS:

--- a/phcovid/phcovid.py
+++ b/phcovid/phcovid.py
@@ -61,7 +61,7 @@ def supplement_data(dataframe, targets):
 
     for df_ in [dataframe, missing]:
         df_["case_no_num"] = (
-            df_["case_no"].apply(lambda x: x.split("H")[-1]).astype(int)
+            df_["case_no"].apply(lambda x: x.split("H")[-1]).astype(np.int64)
         )
 
     # Make sure both dataframe and missing are sorted based on `case_no`
@@ -128,6 +128,9 @@ def get_cases(
     df_aliased["contacts_num"] = df_aliased["contacts"].apply(
         lambda x: parse_numeric(x)
     )
+
+    df_aliased["age"] = df_aliased["age"].astype(np.int8)
+    df_aliased["sex"] = df_aliased["sex"].astype("category")
 
     for col in DATE_COLS:
         df_aliased[col] = df_aliased[col].apply(lambda x: fix_dates(x))


### PR DESCRIPTION
Added means to not break the entire pipeline when the dataset from the DSPH GSheet is filtered or updated that might make the library return an error due to extraction.

Will not solve the completeness of data but at the very least, data should be extracted even when sources are not healthy.

### Note

Dependent on #30 so that this is tested for the typecasting